### PR TITLE
Changed to helm-docs compatible comments

### DIFF
--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 1.1.1
+version: 1.1.2
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -30,93 +30,176 @@ helm install my-release iver-wharf/wharf-helm
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api.ciToken | string | `"changeit"` |  |
-| api.ciUrl | string | `"http://jenkins.example.com/generic-webhook-trigger/invoke"` |  |
-| api.containerPort | int | `8080` |  |
-| api.db.driver | string | `"postgres"` |  |
-| api.db.host | string | `"wharf-db"` |  |
-| api.db.name | string | `"wharf"` |  |
-| api.db.password | string | `"changeit"` |  |
-| api.db.port | string | `"5432"` |  |
-| api.db.username | string | `"postgres"` |  |
-| api.extraEnvs | string | `nil` |  |
-| api.image | string | `"quay.io/iver-wharf/wharf-api:v4.0.0"` |  |
-| api.livenessProbe.httpGet.path | string | `"/health"` |  |
-| api.livenessProbe.httpGet.port | string | `"http"` |  |
-| api.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
-| api.rabbitmq.connAttempts | string | `"10"` |  |
-| api.rabbitmq.enabled | bool | `false` |  |
+| api.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| api.ciToken | string | `"changeit"` | Jenkins webhook secret token used when starting new builds. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.ciUrl | string | `"http://jenkins.example.com/generic-webhook-trigger/invoke"` | Jenkins webhook endpoint used when starting new builds. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.containerPort | int | `8080` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| api.containerSecurityContext | object | `{}` | Security context inside the container. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) |
+| api.db.driver | string | `"postgres"` | Currently only `"postgres"` is a valid value here. Set to `null` or empty string `""` if you wish to populate the `DBHOST`, `DBPORT`, `DBUSER`, `DBPASS` environment variables yourself via `api.extraEnvs` Sets `DBDRIVER` environment variable. Does not support ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.db.host | string | `"wharf-db"` | Database hostname used when connecting to the database. Sets `DBHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.db.name | string | `"wharf"` | Name of the database (or "schema" in MySQL terms) holding all the tables. Sets `DBNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.db.password | string | `"changeit"` | Password used when connecting to the database. Sets `DBPASS` environment variable. Recommended to pull this from a secret. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.db.port | string | `"5432"` | Database port used when connecting to the database. Sets `DBPORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.db.username | string | `"postgres"` | Username used when connecting to the database. Sets `DBUSER` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.extraEnvs | list | `[]` | If `api.db.driver` is unset, then you must populate your own database connection here. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
+| api.image | string | `"quay.io/iver-wharf/wharf-api:v4.0.0"` | Docker image that runs the frontend/web |
+| api.imagePullPolicy | string | `""` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| api.livenessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Unhealthy liveness probes makes pod restart. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| api.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Select which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
+| api.podSecurityContext | object | `{}` | Security context on the pod level. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| api.rabbitmq.connAttempts | string | `"10"` | When the Wharf API starts up, how many times should it attempt to connect to the RabbitMQ instance before giving up and restarting? Sets `RABBITMQCONNATTEMPTS` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.rabbitmq.enabled | bool | `false` | `true` to enable RabbitMQ integration, `false` to disable it. All other `api.rabbitmq...` settings are ignored if RabbitMQ has been disabled. Does not support ["Smart environment fields"](./README.md#smart-environment-fields) |
 | api.rabbitmq.host | string | `"rabbitmq.local"` |  |
-| api.rabbitmq.name | string | `"wharf_queue"` |  |
-| api.rabbitmq.password | string | `"changeit"` |  |
-| api.rabbitmq.port | string | `"5672"` |  |
-| api.rabbitmq.username | string | `"user"` |  |
-| api.rabbitmq.vHost | string | `"/"` |  |
-| api.readinessProbe.httpGet.path | string | `"/health"` |  |
-| api.readinessProbe.httpGet.port | string | `"http"` |  |
-| api.replicaCount | int | `1` |  |
-| api.servicePort | int | `80` |  |
-| api.serviceType | string | `"ClusterIP"` |  |
-| fullnameOverride | string | `""` |  |
-| global.instanceId | string | `"dev"` |  |
-| global.isProduction | bool | `false` |  |
-| global.url | string | `"wharf.example.org"` |  |
+| api.rabbitmq.name | string | `"wharf_queue"` | RabbitMQ queue name to push RabbitMQ messages into. Sets `RABBITMQNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.rabbitmq.password | string | `"changeit"` | Password used by Wharf to authenticate with RabbitMQ. Sets `RABBITMQPASS` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.rabbitmq.port | string | `"5672"` | Host port used by Wharf to connect to RabbitMQ. Sets `RABBITMQPORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.rabbitmq.username | string | `"user"` | Username used by Wharf to authenticate with RabbitMQ. Sets `RABBITMQUSER` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.rabbitmq.vHost | string | `"/"` | RabbitMQ virtual host to push RabbitMQ messages into. Sets `RABBITMQVHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields) |
+| api.readinessProbe | object | `{"httpGet":{"path":"/health","port":"http"}}` | Unhealthy readiness probes makes pod never recieve network traffic. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| api.replicaCount | int | `1` | Number of deployment replicas. |
+| api.resources | object | `{}` | Resource requests and limits. It's best practice to apply some appropriate values here [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| api.servicePort | int | `80` | Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| api.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
+| api.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| fullnameOverride | string | `""` | String to fully override the pod and service names. If set, deployments, services, ingresses, *et.al*, will use this name, and `nameOverride` will be ignored. |
+| global.instanceId | string | `"dev"` | Used in RabbitMQ & Jenkins to multiplex jobs and messages on the same instances while keeping track of their origin. |
+| global.isProduction | bool | `false` | This flag is forwarded to the frontend where it can be used to show slightly different styling depending on if it's for production or not. |
+| global.url | string | `"wharf.example.org"` | URL of this Wharf instance. Mostly only used in the `ingress` and `ingressRoute` settings to route the appropriate requests, but also in Wharf's API so it can properly refer to itself. |
+| imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.apiVersion | string | `"networking.k8s.io/v1beta1"` |  |
-| ingress.enabled | bool | `false` |  |
+| ingress.enabled | bool | `false` | Enables deploying a preconfigured Kubernetes Ingress to route traffic to the different Wharf services, using `global.url` as host name. |
+| ingress.extraPaths | list | `[]` | Optionally add additional paths that will be added on top of the routes for the web `/`, main API `/api`, and the provider APIs `/import/*` |
 | ingress.tls | object | `{}` |  |
 | ingressRoute.apiVersion | string | `"traefik.containo.us/v1alpha1"` |  |
-| ingressRoute.enabled | bool | `false` |  |
-| ingressRoute.entries[0].entryPoints[0] | string | `"web"` |  |
-| ingressRoute.entries[0].name | string | `"http"` |  |
-| ingressRoute.entries[1].entryPoints[0] | string | `"websecure"` |  |
-| ingressRoute.entries[1].name | string | `"https"` |  |
+| ingressRoute.enabled | bool | `false` | Enables deploying a preconfigured Traefik IngressRoute to route traffic to the different Wharf services, using `global.url` as host name. |
+| ingressRoute.entries[0].annotations | object | `{}` |  |
+| ingressRoute.entries[0].entryPoints | list | `["web"]` | Sample Traefik entrypoint that could be for `:80` traffic |
+| ingressRoute.entries[0].middlewares | list | `[]` | Good idea is to hook up the RedirectScheme to redirect http->https |
+| ingressRoute.entries[0].name | string | `"http"` | Only used in the IngressRoute object names |
+| ingressRoute.entries[0].tls | object | `{}` |  |
+| ingressRoute.entries[1].annotations | object | `{}` |  |
+| ingressRoute.entries[1].entryPoints | list | `["websecure"]` | Sample Traefik entrypoint that could be for `:443` traffic |
+| ingressRoute.entries[1].middlewares | list | `[]` |  |
+| ingressRoute.entries[1].name | string | `"https"` | Only used in the IngressRoute object names |
 | ingressRoute.entries[1].tls.secretName | string | `"wharf-example-tls"` |  |
-| nameOverride | string | `""` |  |
-| providers.azuredevops.enabled | bool | `true` |  |
-| providers.azuredevops.image | string | `"quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1"` |  |
-| providers.azuredevops.imagePullPolicy | string | `"IfNotPresent"` |  |
-| providers.azuredevops.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
-| providers.azuredevops.resources.limits.cpu | string | `"100m"` |  |
-| providers.azuredevops.resources.limits.memory | string | `"128Mi"` |  |
-| providers.azuredevops.resources.requests.cpu | string | `"100m"` |  |
-| providers.azuredevops.resources.requests.memory | string | `"128Mi"` |  |
-| providers.github.enabled | bool | `true` |  |
-| providers.github.image | string | `"quay.io/iver-wharf/wharf-provider-github:v1.1.1"` |  |
-| providers.github.imagePullPolicy | string | `"IfNotPresent"` |  |
-| providers.github.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
-| providers.github.resources.limits.cpu | string | `"100m"` |  |
-| providers.github.resources.limits.memory | string | `"128Mi"` |  |
-| providers.github.resources.requests.cpu | string | `"100m"` |  |
-| providers.github.resources.requests.memory | string | `"128Mi"` |  |
-| providers.gitlab.enabled | bool | `true` |  |
-| providers.gitlab.image | string | `"quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1"` |  |
-| providers.gitlab.imagePullPolicy | string | `"IfNotPresent"` |  |
-| providers.gitlab.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
-| providers.gitlab.resources.limits.cpu | string | `"100m"` |  |
-| providers.gitlab.resources.limits.memory | string | `"128Mi"` |  |
-| providers.gitlab.resources.requests.cpu | string | `"100m"` |  |
-| providers.gitlab.resources.requests.memory | string | `"128Mi"` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `nil` |  |
-| web.containerPort | int | `8080` |  |
-| web.image | string | `"quay.io/iver-wharf/wharf-web:v1.2.0"` |  |
-| web.livenessProbe.httpGet.path | string | `"/"` |  |
-| web.livenessProbe.httpGet.port | string | `"http"` |  |
-| web.nodeSelector."kubernetes.io/os" | string | `"linux"` |  |
-| web.readinessProbe.httpGet.path | string | `"/"` |  |
-| web.readinessProbe.httpGet.port | string | `"http"` |  |
-| web.replicaCount | int | `1` |  |
-| web.servicePort | int | `80` |  |
-| web.serviceType | string | `"ClusterIP"` |  |
-| web.volumeMounts[0].mountPath | string | `"/var/cache/nginx"` |  |
-| web.volumeMounts[0].name | string | `"cache"` |  |
-| web.volumeMounts[1].mountPath | string | `"/run"` |  |
-| web.volumeMounts[1].name | string | `"run"` |  |
-| web.volumes[0].emptyDir | object | `{}` |  |
-| web.volumes[0].name | string | `"cache"` |  |
-| web.volumes[1].emptyDir | object | `{}` |  |
-| web.volumes[1].name | string | `"run"` |  |
+| ingressRoute.extraRoutes | list | `[]` | Optionally add additional routes that will be added on top of the routes for the web `/`, main API `/api`, and the provider APIs `/import/*` |
+| nameOverride | string | `""` | String to partially override the pod and service names. Will maintain the release name. |
+| providers.azuredevops.enabled | bool | `true` | There are far more settings available. Take a look at the `providers.exampleProvider.*` settings for a comparison. |
+| providers.azuredevops.image | string | `"quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1"` | Default image used in the `azuredevops` provider |
+| providers.azuredevops.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy used in the `azuredevops` provider |
+| providers.azuredevops.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default node selector for the `azuredevops` provider |
+| providers.azuredevops.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Default resources requested by the `azuredevops` provider |
+| providers.exampleProvider.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| providers.exampleProvider.annotations | object | `{}` | Additional annotations to add to this provider's deployment |
+| providers.exampleProvider.containerPort | int | `8080` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| providers.exampleProvider.containerSecurityContext | object | `{}` | Security context inside the container. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) |
+| providers.exampleProvider.enabled | bool | `false` | If this is `false` or unset then this provider will be ignored. |
+| providers.exampleProvider.extraEnvs | list | `[]` | This chart adds `WHARF_API_URL` and `WHARF_PROVIDER_URL_BASE` environment variables, but you are free to add additional environment variables here. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
+| providers.exampleProvider.image | string | `"ubuntu:latest"` | Docker image that runs the provider API |
+| providers.exampleProvider.imagePullPolicy | string | `""` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| providers.exampleProvider.imagePullSecrets | list | `[]` |  |
+| providers.exampleProvider.labels | object | `{}` | Additional labels to add to this provider's deployment |
+| providers.exampleProvider.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Unhealthy liveness probes makes pod restart. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| providers.exampleProvider.nameOverride | string | `"example-provider"` | The provider name affects the pod name, service name, URL base, et.al. If left unset, it will default to name of `providers.*` map/directory key (ex: `providers.exampleProvider` => `"exampleProvider"`) |
+| providers.exampleProvider.nodeSelector | object | `{}` | Select which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
+| providers.exampleProvider.podAnnotations | object | `{}` |  |
+| providers.exampleProvider.podLabels | object | `{}` | Additional labels to add to this provider's pod |
+| providers.exampleProvider.podSecurityContext | object | `{}` | Security context on the pod level. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| providers.exampleProvider.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Unhealthy readiness probes makes pod never recieve network traffic. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| providers.exampleProvider.replicaCount | int | `1` | Number of deployment replicas. |
+| providers.exampleProvider.resources | object | `{}` | Resource requests and limits. It's best practice to apply some appropriate values here [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| providers.exampleProvider.servicePort | int | `80` | Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| providers.exampleProvider.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
+| providers.exampleProvider.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| providers.exampleProvider.urlBaseOverride | string | `"/import/my-example-provider"` | Overrides URL base path If left unset, it will default to `"/import/"` followed by name of provider (ex: `"/import/example-provider"`). Default is affected by the `providers.*.nameOverride` setting. |
+| providers.github.enabled | bool | `true` | There are far more settings available. Take a look at the `providers.exampleProvider.*` settings for a comparison. |
+| providers.github.image | string | `"quay.io/iver-wharf/wharf-provider-github:v1.1.1"` | Default image used in the `github` provider |
+| providers.github.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy used in the `github` provider |
+| providers.github.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default node selector for the `github` provider |
+| providers.github.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Default resources requested by the `github` provider |
+| providers.gitlab.enabled | bool | `true` | There are far more settings available. Take a look at the `providers.exampleProvider.*` settings for a comparison. |
+| providers.gitlab.image | string | `"quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1"` | Default image used in the `gitlab` provider |
+| providers.gitlab.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy used in the `gitlab` provider |
+| providers.gitlab.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default node selector for the `gitlab` provider |
+| providers.gitlab.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Default resources requested by the GitLab provider |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |
+| web.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| web.containerPort | int | `8080` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| web.containerSecurityContext | object | `{}` | Security context inside the container. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) |
+| web.image | string | `"quay.io/iver-wharf/wharf-web:v1.2.0"` | Docker image that runs the frontend/web |
+| web.imagePullPolicy | string | `""` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| web.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Unhealthy liveness probes makes pod restart. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| web.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Select which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
+| web.podSecurityContext | object | `{}` | Security context on the pod level. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| web.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Unhealthy readiness probes makes pod never recieve network traffic. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) |
+| web.replicaCount | int | `1` | Number of deployment replicas. |
+| web.resources | object | `{}` | Resource requests and limits. It's best practice to apply some appropriate values here [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| web.servicePort | int | `80` | Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
+| web.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
+| web.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| web.volumeMounts | list | `[{"mountPath":"/var/cache/nginx","name":"cache"},{"mountPath":"/run","name":"run"}]` | Recommended to add `emptyDir` volumes for nginx to have faster and more flexible caching. |
+| web.volumes | list | `[{"emptyDir":{},"name":"cache"},{"emptyDir":{},"name":"run"}]` | Recommended to add `emptyDir` volumes for nginx to have faster and more flexible caching. |
+
+## Smart environment fields
+
+This chart uses a trick to let you more consicely specify environment variable
+values. Normally to specify a Kubernetes environment variable, you have a
+setting such as:
+
+```yaml
+env:
+  - name: "DBHOST"
+    value: "my value"
+
+  - name: "DBHOST"
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: my-key-in-the-secret
+```
+
+Any setting that specifies it supports "Smart environment field", such as the
+`api.db.host` setting, allows these values except the `name` field.
+
+But there's also a shorthand. If the value of the setting is just simply a
+`string`, then it translates to a `value: ...` setting.
+
+The following three samples of setting `api.db.host` are all valid:
+
+```yaml
+api:
+  db:
+    host:
+      value: "my value"
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    value: "my value"
+
+    host:
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: my-key-in-the-secret
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: my-secret
+    #        key: my-key-in-the-secret
+
+    host: "my value"
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    value: "my value"
+```
+
+The object fields available, such as the `value` and `valueFrom`, can be found
+over at: <https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables>
 
 ## Changes
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>

--- a/charts/wharf-helm/README.md.gotmpl
+++ b/charts/wharf-helm/README.md.gotmpl
@@ -28,6 +28,65 @@ helm install my-release iver-wharf/wharf-helm
 
 {{ template "chart.valuesSection" . }}
 
+## Smart environment fields
+
+This chart uses a trick to let you more consicely specify environment variable
+values. Normally to specify a Kubernetes environment variable, you have a
+setting such as:
+
+```yaml
+env:
+  - name: "DBHOST"
+    value: "my value"
+
+  - name: "DBHOST"
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: my-key-in-the-secret
+```
+
+Any setting that specifies it supports "Smart environment field", such as the
+`api.db.host` setting, allows these values except the `name` field.
+
+But there's also a shorthand. If the value of the setting is just simply a
+`string`, then it translates to a `value: ...` setting.
+
+The following three samples of setting `api.db.host` are all valid:
+
+```yaml
+api:
+  db:
+    host:
+      value: "my value"
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    value: "my value"
+
+    host:
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: my-key-in-the-secret
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: my-secret
+    #        key: my-key-in-the-secret
+
+    host: "my value"
+    # Would be added to the Pod's environment variables as:
+    #env:
+    #  - name: DBHOST
+    #    value: "my value"
+```
+
+The object fields available, such as the `value` and `valueFrom`, can be found
+over at: <https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables>
+
 ## Changes
 
 See the [CHANGELOG.md](./CHANGELOG.md) file inside this Helm chart.

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -1,34 +1,41 @@
+# -- String to partially override the pod and service names. Will maintain the
+# release name.
 nameOverride: ""
+# -- String to fully override the pod and service names. If set, deployments,
+# services, ingresses, *et.al*, will use this name, and `nameOverride` will be
+# ignored.
 fullnameOverride: ""
 
 global:
+  # -- URL of this Wharf instance. Mostly only used in the `ingress` and
+  # `ingressRoute` settings to route the appropriate requests, but also in
+  # Wharf's API so it can properly refer to itself.
   url: wharf.example.org
-  ## Used in RabbitMQ & Jenkins to multiplex jobs and messages on the same
-  ## instances while keeping track of their origin.
+  # -- Used in RabbitMQ & Jenkins to multiplex jobs and messages on the same
+  # instances while keeping track of their origin.
   instanceId: dev
-  ## This flag is forwarded to the frontend where it can be used to show
-  ## slightly different styling depending on if it's for production or not.
+  # -- This flag is forwarded to the frontend where it can be used to show
+  # slightly different styling depending on if it's for production or not.
   isProduction: false
 
 web:
-  ## Defaults to 1
+  # -- Number of deployment replicas.
   replicaCount: 1
 
-  ## Docker image that runs the frontend/web
+  # -- Docker image that runs the frontend/web
   image: quay.io/iver-wharf/wharf-web:v1.2.0
 
-  ## Defaults to unset
-  ## Read more: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-  #imagePullPolicy: IfNotPresent
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+  imagePullPolicy: ""
   
-  ## Security context on the pod level. Defaults to unset
-  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  #podSecurityContext:
+  # -- Security context on the pod level.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext: {}
   #  fsGroup: 2000
   
-  ## Security context inside the container. Defaults to unset
-  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
-  #containerSecurityContext:
+  # -- Security context inside the container.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container)
+  containerSecurityContext: {}
   #  capabilities:
   #    drop:
   #    - ALL
@@ -38,10 +45,10 @@ web:
   #  runAsNonRoot: true
   #  runAsUser: 1000
 
-  ## This defaults to no limits. It's best practice to apply some
-  ## appropriate values here
-  ## Read more: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  #resources:
+  # -- Resource requests and limits. It's best practice to apply some
+  # appropriate values here
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources: {}
   #  limits:
   #    cpu: 100m
   #    memory: 128Mi
@@ -49,61 +56,69 @@ web:
   #    cpu: 100m
   #    memory: 128Mi
 
+  # -- Unhealthy liveness probes makes pod restart.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   livenessProbe:
     httpGet:
       path: /
       port: http
 
+  # -- Unhealthy readiness probes makes pod never recieve network traffic.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   readinessProbe:
     httpGet:
       path: /
       port: http
 
-  ## Defaults to 'kubernetes.io/os=linux'
+  # -- Select which node to run on, based on node labels.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)
   nodeSelector:
     kubernetes.io/os: linux
 
-  #tolerations: []
-  #affinity: {}
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+  tolerations: []
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+  affinity: {}
   
-  ## Recommended to set these for nginx to have faster and more flexible caching
-  ## Defaults to emptyDir on '/run' and '/var/cache/nginx' dirs
+  # -- Recommended to add `emptyDir` volumes for nginx to have faster and more flexible caching.
   volumes:
     - name: cache
       emptyDir: {}
     - name: run
       emptyDir: {}
+  # -- Recommended to add `emptyDir` volumes for nginx to have faster and more flexible caching.
   volumeMounts:
     - name: cache
       mountPath: /var/cache/nginx
     - name: run
       mountPath: /run
 
-  ## Defaults to ClusterIP
+  # -- Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
   serviceType: ClusterIP
-  ## Defaults to 80
+  # -- Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   servicePort: 80
-  ## Defaults to 8080
+  # -- Container port. This needs to correlate to the port that the application
+  # listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   containerPort: 8080
 
 api:
-  ## Defaults to 1
+  # -- Number of deployment replicas.
   replicaCount: 1
 
+  # -- Docker image that runs the frontend/web
   image: quay.io/iver-wharf/wharf-api:v4.0.0
   
-  ## Defaults to unset
-  ## Read more: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-  #imagePullPolicy: IfNotPresent
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+  imagePullPolicy: ""
 
-  ## Security context on the pod level. Defaults to unset
-  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  #podSecurityContext:
+  # -- Security context on the pod level.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext: {}
   #  fsGroup: 2000
 
-  ## Security context inside the container. Defaults to unset
-  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
-  #containerSecurityContext:
+  # -- Security context inside the container.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container)
+  containerSecurityContext: {}
   #  capabilities:
   #    drop:
   #    - ALL
@@ -111,10 +126,10 @@ api:
   #  runAsNonRoot: true
   #  runAsUser: 1000
 
-  ## This defaults to no limits. It's best practice to apply some
-  ## appropriate values here
-  ## Read more: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  #resources:
+  # -- Resource requests and limits. It's best practice to apply some
+  # appropriate values here
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  resources: {}
   #  limits:
   #    cpu: 100m
   #    memory: 128Mi
@@ -122,35 +137,43 @@ api:
   #    cpu: 100m
   #    memory: 128Mi
 
-  readinessProbe:
-    httpGet:
-      path: /health
-      port: http
-
+  # -- Unhealthy liveness probes makes pod restart.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   livenessProbe:
     httpGet:
       path: /health
       port: http
 
-  ## Defaults to 'kubernetes.io/os=linux'
+  # -- Unhealthy readiness probes makes pod never recieve network traffic.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+
+  # -- Select which node to run on, based on node labels.
+  # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)
   nodeSelector:
     kubernetes.io/os: linux
 
-  #tolerations: []
-  #affinity: {}
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+  tolerations: []
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+  affinity: {}
 
-  ## Defaults to ClusterIP
+  # -- Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
   serviceType: ClusterIP
-  ## Defaults to 80
+  # -- Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   servicePort: 80
-  ## Defaults to 8080
+  # -- Container port. This needs to correlate to the port that the application
+  # listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   containerPort: 8080
   
-  ## Jenkins webhook endpoint used when starting new builds.
-  ## Supports string or Kubernetes environments setting map, without the 'name:'
+  # -- Jenkins webhook endpoint used when starting new builds.
+  # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
   ciUrl: http://jenkins.example.com/generic-webhook-trigger/invoke
-  ## Jenkins webhook secret token used when starting new builds.
-  ## Supports string or Kubernetes environments setting map, without the 'name:'
+  # -- Jenkins webhook secret token used when starting new builds.
+  # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
   ciToken: changeit
   #ciToken:
   #  valueFrom:
@@ -158,28 +181,29 @@ api:
   #      name: wharf-jenkins-secrets
   #      key: webhook-token
 
-  ## Settings for Wharf API's database connection
+  # Settings for Wharf API's database connection
   db:
-    ## Currently only "postgres" is a valid value here. Set to null or empty
-    ## string if you wish to populate the DBHOST, DBPORT, DBUSER, DBPASS
-    ## environment variables yourself via .Values.api.extraEnvs.
-    ## Defaults to "postgres"
+    # -- Currently only `"postgres"` is a valid value here. Set to `null` or
+    # empty string `""` if you wish to populate the `DBHOST`, `DBPORT`,
+    # `DBUSER`, `DBPASS` environment variables yourself via `api.extraEnvs`
+    # Sets `DBDRIVER` environment variable.
+    # Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
     driver: postgres
   
-    ## Name of the database (or "schema" in MySQL terms) holding all the tables.
-    ## Defaults to "wharf"
+    # -- Name of the database (or "schema" in MySQL terms) holding all the
+    # tables. Sets `DBNAME` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     name: wharf
 
-    ## Username used when connecting to the database. Sets "DBUSER".
-    ## Defaults to 'value: postgres'
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
-    ## Read more: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+    # -- Username used when connecting to the database.
+    # Sets `DBUSER` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     username: postgres
   
-    ## Password used when connecting to the database. Sets "DBPASS".
-    ## Recommended to pull this from a secret.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
-    ## Read more: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+    # -- Password used when connecting to the database.
+    # Sets `DBPASS` environment variable.
+    # Recommended to pull this from a secret.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     password: changeit
     #password:
     #  valueFrom:
@@ -187,55 +211,64 @@ api:
     #      name: my-wharf-postgres-cred-secret
     #      key: postgresql-password
 
-    ## Database hostname used when connecting to the database. Sets "DBHOST".
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
-    ## Read more: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+    # -- Database hostname used when connecting to the database.
+    # Sets `DBHOST` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     host: wharf-db
 
-    ## Database port used when connecting to the database. Sets "DBPORT".
-    ## Defaults to "5432" (Integers must be quoted!)
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
-    ## Read more: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
+    # -- Database port used when connecting to the database.
+    # Sets `DBPORT` environment variable. ***(Integers must be quoted!)***
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     port: "5432"
 
-  ## Settings Wharf API's integration with RabbitMQ
+  # Settings Wharf API's integration with RabbitMQ
   rabbitmq:
-    ## true to enable RabbitMQ integration, false to disable it.
-    ## Defaults to false/disabled.
-    ## All other .Values.api.rabbitmq* settings are ignored if RabbitMQ has been
-    ## disabled.
+    # -- `true` to enable RabbitMQ integration, `false` to disable it.
+    # All other `api.rabbitmq...` settings are ignored if RabbitMQ has been
+    # disabled.
+    # Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
     enabled: false
-    ## Username used by Wharf to authenticate with RabbitMQ.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- Username used by Wharf to authenticate with RabbitMQ.
+    # Sets `RABBITMQUSER` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     username: user
-    ## Password used by Wharf to authenticate with RabbitMQ.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- Password used by Wharf to authenticate with RabbitMQ.
+    # Sets `RABBITMQPASS` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     password: changeit
     #password:
     #  valueFrom:
     #    secretKeyRef:
     #      name: rabbitmq-auth
     #      value: password
-    ## Host name (without the protocol) used by Wharf to connect to RabbitMQ.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- Host name *(without the protocol)* used by Wharf to connect to RabbitMQ.
+    # Sets `RABBITMQHOST` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     host: rabbitmq.local
-    ## Host port used by Wharf to connect to RabbitMQ.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- Host port used by Wharf to connect to RabbitMQ.
+    # Sets `RABBITMQPORT` environment variable. ***(Integers must be quoted!)***
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     port: "5672"
-    ## RabbitMQ virtual host to push RabbitMQ messages into.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- RabbitMQ virtual host to push RabbitMQ messages into.
+    # Sets `RABBITMQVHOST` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     vHost: /
-    ## RabbitMQ queue name to push RabbitMQ messages into.
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- RabbitMQ queue name to push RabbitMQ messages into.
+    # Sets `RABBITMQNAME` environment variable.
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     name: wharf_queue
-    ## When the Wharf API starts up, how many times should it attempt to connect
-    ## to the RabbitMQ instance before giving up and restarting?
-    ## Supports string or Kubernetes environments setting map, without the 'name:'
+    # -- When the Wharf API starts up, how many times should it attempt to connect
+    # to the RabbitMQ instance before giving up and restarting?
+    # Sets `RABBITMQCONNATTEMPTS` environment variable.
+    # ***(Integers must be quoted!)***
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     connAttempts: "10"
 
-  extraEnvs:
-    ## If .Values.api.dbDriver is unset, then you must populate your own
-    ## database connection here.
+
+  # -- If `api.db.driver` is unset, then you must populate your own
+  # database connection here.
+  # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  extraEnvs: []
     #- name: DBHOST
     #  value: wharf-db
     #- name: DBPORT
@@ -245,123 +278,137 @@ api:
     #- name: DBPASS
     #  value: changeit
 
+# Provider settings. You are free to add more providers here. This is done by
+# adding new keys to this map. For example, adding `providers.gitea.enabled`,
+# `providers.gitea.image`, etc.
 providers:
-  ## You are free to add more providers here.
-  #myNewProvider:
-  #  ## If this is false or unset then this provider will be ignored.
-  #  enabled: true
-  #
-  #  ## The provider name affects the pod name, service name, URL base, et.al.
-  #  ## Defaults to name of .Values.providers map/directory key (ex: "myNewProvider")
-  #  #nameOverride: myNewProvider
-  #
-  #  ## Overrides URL base path
-  #  ## Defaults to "/import/" followed by name of provider
-  #  ## (ex: "/import/myNewProvider"). Default is affected by the
-  #  ## .Values.providers.X.nameOverride setting.
-  #  #urlBaseOverride: /import/myNewProvider
-  #
-  #  ## Defaults to 1
-  #  #replicaCount: 1
-  #
-  #  ## Docker image that runs the provider API
-  #  image: ubuntu:latest
-  #
-  #  ## Defaults to unset
-  #  ## Read more: https://kubernetes.io/docs/concepts/containers/images/#updating-images
-  #  #imagePullPolicy: IfNotPresent
-  #
-  #  ## Defaults to .Values.imagePullSecrets
-  #  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  #  #imagePullSecrets:
-  #  #  - name: myDockerCredentialsSecret
-  #
-  #  ## Additional labels to add to the deployment
-  #  #labels:
-  #  #  app: my-new-wharf-provider
-  #
-  #  ## Additional annotations to add to the deployment
-  #  #annotations:
-  #  #  prometheus.io/scrape: "true"
-  #
-  #  ## Additional labels to add to the pod
-  #  #podLabels:
-  #  #  app: my-new-wharf-provider
-  #
-  #  ## Additional annotations to add to the pod
-  #  #podAnnotations:
-  #  #  prometheus.io/scrape: "true"
-  #
-  #  ## Defaults to 8080
-  #  #containerPort: 8080
-  #
-  #  ## Defaults to ClusterIP
-  #  #serviceType: ClusterIP
-  #
-  #  ## Defaults to 80
-  #  #servicePort: 80
-  #
-  #  ## Security context on the pod level. Defaults to unset
-  #  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  #  #podSecurityContext:
-  #  #  fsGroup: 2000
-  #
-  #  ## Security context inside the container. Defaults to unset
-  #  ## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
-  #  #containerSecurityContext:
-  #  #  capabilities:
-  #  #    drop:
-  #  #    - ALL
-  #  #  readOnlyRootFilesystem: true
-  #  #  runAsNonRoot: true
-  #  #  runAsUser: 1000
-  #
-  #  ## This defaults to no limits. It's best practice to apply some
-  #  ## appropriate values here
-  #  #resources:
-  #  #  limits:
-  #  #    cpu: 100m
-  #  #    memory: 128Mi
-  #  #  requests:
-  #  #    cpu: 100m
-  #  #    memory: 128Mi
-  #
-  #  ## Defaults to unset
-  #  #nodeSelector: {}
-  #
-  #  ## Defaults to unset
-  #  #tolerations: []
-  #
-  #  ## Defaults to unset
-  #  #affinity: {}
-  #
-  #  ## Wharf adds the following environment variable:
-  #  ##   WHARF_API_URL={.Values.global.url}/api
-  #  ##   WHARF_PROVIDER_URL_BASE={.Values.global.url}/api/import/{.Values.providers.*.name}
-  #  ## But you can add more with this block:
-  #  #extraEnvs:
-  #  #  - name: MY_ENV_VALUE:
-  #  #    value: foo
-  #  #  - name: MY_ENV_SECRET:
-  #  #    valueFrom:
-  #  #      secretKeyRef:
-  #  #        name: some-k8s-secret-name
-  #  #        key: some-k8s-secret-key
-  #
-  #  ## Defaults to 'httpGet' on path '/'
-  #  #livenessProbe:
-  #  #  httpGet:
-  #  #    path: /
-  #  #    port: http
-  #  #readinessProbe:
-  #  #  httpGet:
-  #  #    path: /
-  #  #    port: http
+  # Example new provider, with all of its settings.
+  exampleProvider:
+    # -- If this is `false` or unset then this provider will be ignored.
+    enabled: false
+  
+    # -- The provider name affects the pod name, service name, URL base, et.al.
+    # If left unset, it will default to name of `providers.*` map/directory key
+    # (ex: `providers.exampleProvider` => `"exampleProvider"`)
+    nameOverride: example-provider
+  
+    # -- Overrides URL base path
+    # If left unset, it will default to `"/import/"` followed by name of
+    # provider (ex: `"/import/example-provider"`). Default is affected by the
+    # `providers.*.nameOverride` setting.
+    urlBaseOverride: /import/my-example-provider
+  
+    # -- Number of deployment replicas.
+    replicaCount: 1
+  
+    # -- Docker image that runs the provider API
+    image: ubuntu:latest
+  
+    # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+    imagePullPolicy: ""
+  
+    # Defaults to `imagePullSecrets`.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecrets: []
+    #  - name: myDockerCredentialsSecret
+  
+    # -- Additional labels to add to this provider's deployment
+    labels: {}
+    #  app: my-new-wharf-provider
+  
+    # -- Additional annotations to add to this provider's deployment
+    annotations: {}
+    #  prometheus.io/scrape: "true"
+  
+    # -- Additional labels to add to this provider's pod
+    podLabels: {}
+    #  app: my-new-wharf-provider
+  
+    # Additional annotations to add to this provider's pod
+    podAnnotations: {}
+    #  prometheus.io/scrape: "true"
+  
+    # -- Security context on the pod level.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+    podSecurityContext: {}
+    #  fsGroup: 2000
+  
+    # -- Security context inside the container.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container)
+    containerSecurityContext: {}
+    #  capabilities:
+    #    drop:
+    #    - ALL
+    #  readOnlyRootFilesystem: true
+    #  runAsNonRoot: true
+    #  runAsUser: 1000
+  
+    # -- Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+    serviceType: ClusterIP
+
+    # -- Service port. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
+    servicePort: 80
+  
+    # -- Container port. This needs to correlate to the port that the application
+    # listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
+    containerPort: 8080
+  
+    # -- Resource requests and limits. It's best practice to apply some
+    # appropriate values here
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+    resources: {}
+    #  limits:
+    #    cpu: 100m
+    #    memory: 128Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 128Mi
+  
+    # -- Select which node to run on, based on node labels.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)
+    nodeSelector: {}
+  
+    # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
+    tolerations: []
+    # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+    affinity: {}
+  
+    # -- This chart adds `WHARF_API_URL` and `WHARF_PROVIDER_URL_BASE`
+    # environment variables, but you are free to add additional environment
+    # variables here.
+    # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+    extraEnvs: []
+    #  - name: MY_ENV_VALUE:
+    #    value: foo
+    #  - name: MY_ENV_SECRET:
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: some-k8s-secret-name
+    #        key: some-k8s-secret-key
+  
+    # -- Unhealthy liveness probes makes pod restart.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+
+    # -- Unhealthy readiness probes makes pod never recieve network traffic.
+    # [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
 
   gitlab:
+    # -- There are far more settings available. Take a look at the
+    # `providers.exampleProvider.*` settings for a comparison.
     enabled: true
+    # -- Default image used in the `gitlab` provider
     image: quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1
+    # -- Default image pull policy used in the `gitlab` provider
     imagePullPolicy: IfNotPresent
+    # -- Default resources requested by the GitLab provider
     resources:
       limits:
         cpu: 100m
@@ -369,13 +416,19 @@ providers:
       requests:
         cpu: 100m
         memory: 128Mi
+    # -- Default node selector for the `gitlab` provider
     nodeSelector:
       kubernetes.io/os: linux
 
   github:
+    # -- There are far more settings available. Take a look at the
+    # `providers.exampleProvider.*` settings for a comparison.
     enabled: true
+    # -- Default image used in the `github` provider
     image: quay.io/iver-wharf/wharf-provider-github:v1.1.1
+    # -- Default image pull policy used in the `github` provider
     imagePullPolicy: IfNotPresent
+    # -- Default resources requested by the `github` provider
     resources:
       limits:
         cpu: 100m
@@ -383,13 +436,19 @@ providers:
       requests:
         cpu: 100m
         memory: 128Mi
+    # -- Default node selector for the `github` provider
     nodeSelector:
       kubernetes.io/os: linux
 
   azuredevops:
+    # -- There are far more settings available. Take a look at the
+    # `providers.exampleProvider.*` settings for a comparison.
     enabled: true
+    # -- Default image used in the `azuredevops` provider
     image: quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1
+    # -- Default image pull policy used in the `azuredevops` provider
     imagePullPolicy: IfNotPresent
+    # -- Default resources requested by the `azuredevops` provider
     resources:
       limits:
         cpu: 100m
@@ -397,30 +456,34 @@ providers:
       requests:
         cpu: 100m
         memory: 128Mi
+    # -- Default node selector for the `azuredevops` provider
     nodeSelector:
       kubernetes.io/os: linux
 
-## Read more: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-#imagePullSecrets:
+# [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+imagePullSecrets: []
 #  - name: myDockerCredentialsSecret
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
+  # -- The name of the service account to use.
+  # If not set and `serviceAccount.create` is `true`, a name is generated using
+  # the fullname template
+  name: ""
 
 ingress:
+  # -- Enables deploying a preconfigured Kubernetes Ingress to route traffic
+  # to the different Wharf services, using `global.url` as host name.
   enabled: false
   apiVersion: networking.k8s.io/v1beta1
   annotations: {}
   tls: {}
     # secretName: wharf-example-tls
 
-  ## Optionally add additional paths that will be added on top of the routes
-  ## for the web (/), main API (/api), and the provider APIs (/import/*)
-  #extraPaths:
+  # -- Optionally add additional paths that will be added on top of the routes
+  # for the web `/`, main API `/api`, and the provider APIs `/import/*`
+  extraPaths: []
   #  - path: /logstash
   #    backend:
   #      serviceName: wharf-logstash
@@ -428,31 +491,37 @@ ingress:
 
 # Traefik IngressRoute
 ingressRoute:
+  # -- Enables deploying a preconfigured Traefik IngressRoute to route traffic
+  # to the different Wharf services, using `global.url` as host name.
   enabled: false
   apiVersion: traefik.containo.us/v1alpha1
 
   entries:
-    - name: http # Only used in the IngressRoute object names
+    - # -- Only used in the IngressRoute object names
+      name: http
+      # -- Sample Traefik entrypoint that could be for `:80` traffic
       entryPoints:
-        - web # Sample entrypoint that could be for :80 traffic
-      ## Good idea is to hook up the RedirectScheme to redirect http->https
-      #middlewares:
+        - web
+      # -- Good idea is to hook up the RedirectScheme to redirect http->https
+      middlewares: []
       #  - name: httpredirect
       #    namespace: default
-      #tls: {}
-      #annotations: {}
+      tls: {}
+      annotations: {}
 
-    - name: https # Only used in the IngressRoute object names
+    - # -- Only used in the IngressRoute object names
+      name: https
+      # -- Sample Traefik entrypoint that could be for `:443` traffic
       entryPoints:
-        - websecure # Sample entrypoint that could be for :443 traffic
-      #middlewares: []
+        - websecure
+      middlewares: []
       tls:
         secretName: wharf-example-tls
-      #annotations: {}
+      annotations: {}
 
-  ## Optionally add additional routes that will be added on top of the routes
-  ## for the web (/), main API (/api), and the provider APIs (/import/*)
-  #extraRoutes:
+  # -- Optionally add additional routes that will be added on top of the routes
+  # for the web `/`, main API `/api`, and the provider APIs `/import/*`
+  extraRoutes: []
   #  - kind: Rule
   #    match: Host(`wharf.example.com`) && PathPrefix(`/logstash`)
   #    services:


### PR DESCRIPTION
helm-docs requires a double-dash (`--`) in order to recognize comments. It also has some other syntaxes that I did not take use of, except the fact that the text in rendered in the README.md as markdown, so there's some markdown text in the comments now.

---

Closes #10
