### PR TITLE
Changed GIN_MODE and wharf-web image tag

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -17,7 +17,7 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed image version of `web` from v1.2.0 to v1.3.0. (#15)
 
-- Added `GIN_MODE=release` environment variable to `api` service when
+- Added `GIN_MODE=release` environment variable to all API services when
   `.Values.global.isProduction` is set, which will suppress debug logs. (#15)
 
 ## v1.1.2-v1.1.4

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,17 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.1.5
+
+- Changed image version of `web` from v1.2.0 to v1.3.0. (#15)
+
+- Added `GIN_MODE=release` environment variable to `api` service when
+  `.Values.global.isProduction` is set, which will suppress debug logs. (#15)
+
+## v1.1.2-v1.1.4
+
+- Changed documentation. Nothing major. (#12, #13, #14)
+
 ## v1.1.1
 
 - Changed to use real [Quay.io images](https://quay.io/organization/iver-wharf)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 1.1.4
+version: 1.1.5
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -33,7 +33,7 @@ helm install my-release iver-wharf/wharf-helm
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.0.0](https://img.shields.io/badge/Version-v4.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.0.0"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.2.0"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.0"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v1.1.1"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1"`
@@ -731,7 +731,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.2.0"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.0"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -53,6 +53,11 @@ spec:
             - name: CI_TOKEN
               {{- .Values.api.ciToken | include "wharf-helm.environmentValue" | nindent 14 }}
 
+            {{- if .Values.global.isProduction }}
+            - name: GIN_MODE
+              value: release
+            {{- end }}
+
             {{- with .Values.api.rabbitmq }}
             {{- if .enabled }}
             - name: RABBITMQENABLED

--- a/charts/wharf-helm/templates/provider.yaml
+++ b/charts/wharf-helm/templates/provider.yaml
@@ -76,7 +76,7 @@ spec:
               value: {{ printf "http://%s-api" $fullName | quote }}
             - name: WHARF_PROVIDER_URL_BASE
               value: {{ $providerUrlBase | quote }}
-            {{- if .Values.global.isProduction }}
+            {{- if $.Values.global.isProduction }}
             - name: GIN_MODE
               value: release
             {{- end }}

--- a/charts/wharf-helm/templates/provider.yaml
+++ b/charts/wharf-helm/templates/provider.yaml
@@ -76,6 +76,10 @@ spec:
               value: {{ printf "http://%s-api" $fullName | quote }}
             - name: WHARF_PROVIDER_URL_BASE
               value: {{ $providerUrlBase | quote }}
+            {{- if .Values.global.isProduction }}
+            - name: GIN_MODE
+              value: release
+            {{- end }}
             {{- with $provider.extraEnvs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.2.0
+  image: quay.io/iver-wharf/wharf-web:v1.3.0
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""


### PR DESCRIPTION
GIN_MODE is now set to release when isProduction is enabled, which hides
a lot of the debug logs which can somtimes contain confidential info.

There was a new release of the wharf-web as well. So I'm bumping that.
