### PR TITLE
Updated images to latest and greatest

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -15,7 +15,7 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.2.1
 
-- Changed image version of `web` from v1.3.1 to v1.3.2. (#18)
+- Changed image version of `web` from v1.3.1 to v1.3.3. (#18)
 - Changed image version of `api` from v4.1.0 to v4.1.1. (#18)
 - Changed image version of `providers.github` from v1.1.1 to v2.0.0. (#18)
 - Changed image version of `providers.gitlab` from v1.1.1 to v1.2.0. (#18)

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,14 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.2.1
+
+- Changed image version of `web` from v1.3.1 to v1.3.2. (#18)
+- Changed image version of `api` from v4.1.0 to v4.1.1. (#18)
+- Changed image version of `providers.github` from v1.1.1 to v2.0.0. (#18)
+- Changed image version of `providers.gitlab` from v1.1.1 to v1.2.0. (#18)
+- Changed image version of `providers.azuredevops` from v1.1.1 to v1.2.0. (#18)
+
 ## v1.2.0
 
 - Added more environment variables for the Wharf API: (#17)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -33,7 +33,7 @@ helm install my-release iver-wharf/wharf-helm
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.1.1](https://img.shields.io/badge/Version-v4.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.1.1"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.2](https://img.shields.io/badge/Version-v1.3.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.2"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.3](https://img.shields.io/badge/Version-v1.3.3-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.3"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0"`
@@ -766,7 +766,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.2"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.3"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -32,11 +32,11 @@ helm install my-release iver-wharf/wharf-helm
 
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
-| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.1.0](https://img.shields.io/badge/Version-v4.1.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.1.0"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.1](https://img.shields.io/badge/Version-v1.3.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.1"`
-| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v1.1.1"`
-| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1"`
-| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v1.1.1](https://img.shields.io/badge/Version-v1.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1"`
+| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.1.1](https://img.shields.io/badge/Version-v4.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.1.1"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.2](https://img.shields.io/badge/Version-v1.3.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.2"`
+| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
+| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
+| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0"`
 
 ## Values
 
@@ -143,7 +143,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-api:v4.1.0"`
+*Default:* `"quay.io/iver-wharf/wharf-api:v4.1.1"`
 
 ### `api.imagePullPolicy`
 
@@ -451,7 +451,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `azuredevops` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0"`
 
 ### `providers.azuredevops.imagePullPolicy`
 
@@ -668,7 +668,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `github` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-github:v1.1.1"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
 
 ### `providers.github.imagePullPolicy`
 
@@ -703,7 +703,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `gitlab` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
 
 ### `providers.gitlab.imagePullPolicy`
 
@@ -766,7 +766,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.1"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.2"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.3.2
+  image: quay.io/iver-wharf/wharf-web:v1.3.3
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.3.1
+  image: quay.io/iver-wharf/wharf-web:v1.3.2
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -106,7 +106,7 @@ api:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-api:v4.1.0
+  image: quay.io/iver-wharf/wharf-api:v4.1.1
   
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -435,7 +435,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `gitlab` provider
-    image: quay.io/iver-wharf/wharf-provider-gitlab:v1.1.1
+    image: quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0
     # -- Default image pull policy used in the `gitlab` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the GitLab provider
@@ -455,7 +455,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `github` provider
-    image: quay.io/iver-wharf/wharf-provider-github:v1.1.1
+    image: quay.io/iver-wharf/wharf-provider-github:v2.0.0
     # -- Default image pull policy used in the `github` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `github` provider
@@ -475,7 +475,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `azuredevops` provider
-    image: quay.io/iver-wharf/wharf-provider-azuredevops:v1.1.1
+    image: quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0
     # -- Default image pull policy used in the `azuredevops` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `azuredevops` provider


### PR DESCRIPTION
wharf-api: v4.1.0 -> v4.1.1
wharf-web: v1.3.1 -> v1.3.3
wharf-provider-gitlab: v1.1.1 -> v1.2.0
wharf-provider-github: v1.1.1 -> v2.0.0 :tada:
wharf-provider-azuredevops: v1.1.1 -> v1.2.0
