### PR TITLE
Added PR template

### DIFF
--- a/.github/.remarkrc
+++ b/.github/.remarkrc
@@ -1,0 +1,15 @@
+{
+    "plugins": [
+        "preset-lint-markdown-style-guide",
+        ["lint-list-item-indent", "space"],
+        ["lint-ordered-list-marker-value", "ordered"],
+        ["lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
+        ["stringify", {
+            "bullet": "-",
+            "fences": true,
+            "listItemIndent": "one",
+            "rule": "-"
+        }],
+        ["lint-maximum-line-length", false]
+    ]
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+- \[ ] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
+  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
+  (but without version dates nor WIP versions)
+
+## Summary
+
+What did you add, change, or remove, concretely?
+
+## Motivation
+
+What bug or problem does this solve?

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "lint": "remark .",
-    "lint-fix": "remark . -o"
+    "lint": "remark . .github",
+    "lint-fix": "remark . .github -o"
   },
   "devDependencies": {
     "remark-cli": "^9.0.0",


### PR DESCRIPTION
## Summary

Added a single PR template, based on https://github.com/iver-wharf/wharf-provider-gitlab/pull/19

No release template for this repository, as the releases are done automatically.

## Motivation

To enforce better PR descriptions
