### PR TITLE
Updated api, web & azure image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6d3504733d1844c49a8678633b1a78f8)](https://www.codacy.com/gh/iver-wharf/wharf-helm/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=iver-wharf/wharf-helm&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6d3504733d1844c49a8678633b1a78f8)](https://www.codacy.com/gh/iver-wharf/wharf-helm/dashboard?utm_source=github.com\&utm_medium=referral\&utm_content=iver-wharf/wharf-helm\&utm_campaign=Badge_Grade)
 
 Repository of Wharf's [Helm](https://helm.sh/) charts. Currently hosting:
 
@@ -24,7 +24,7 @@ The `README.md` files in each chart is generated using
    If you have Go installed, you may run:
 
    ```sh
-   go get -u github.com/norwoodj/helm-docs/cmd/helm-docs
+   go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.5.0
    ```
 
 2. Run `helm-docs`, preferrably before you create your pull requests:

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,18 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.0.0
+
+- BREAKING: Changed image version of `providers.azuredevops` from v1.2.0 to
+  v2.0.1. (#20)
+
+  See the changes on the release page [v2.0.0 wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops/releases/tag/v2.0.0)
+  to list all breaking changes.
+
+- Changed image version of `web` from v1.3.3 to v1.4.0. (#20)
+
+- Changed image version of `api` from v4.1.1 to v4.2.0. (#20)
+
 ## v1.2.1
 
 - Changed image version of `web` from v1.3.1 to v1.3.3. (#18)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 1.2.1
+version: 2.0.0
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -32,11 +32,11 @@ helm install my-release iver-wharf/wharf-helm
 
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
-| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.1.1](https://img.shields.io/badge/Version-v4.1.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.1.1"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.3.3](https://img.shields.io/badge/Version-v1.3.3-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.3.3"`
+| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.2.0](https://img.shields.io/badge/Version-v4.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.2.0"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.4.0](https://img.shields.io/badge/Version-v1.4.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.4.0"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
-| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0"`
+| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
 ## Values
 
@@ -143,7 +143,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-api:v4.1.1"`
+*Default:* `"quay.io/iver-wharf/wharf-api:v4.2.0"`
 
 ### `api.imagePullPolicy`
 
@@ -451,7 +451,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `azuredevops` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
 ### `providers.azuredevops.imagePullPolicy`
 
@@ -766,7 +766,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.3.3"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.4.0"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.3.3
+  image: quay.io/iver-wharf/wharf-web:v1.4.0
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -106,7 +106,7 @@ api:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-api:v4.1.1
+  image: quay.io/iver-wharf/wharf-api:v4.2.0
   
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -475,7 +475,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `azuredevops` provider
-    image: quay.io/iver-wharf/wharf-provider-azuredevops:v1.2.0
+    image: quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1
     # -- Default image pull policy used in the `azuredevops` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `azuredevops` provider


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Upped chart version to v2.0.0.

- Updated docs in README.md about helm-docs as there was a bug in v1.6.0 that I don't have time to deal with right now. Sticking to v1.5.0 for now, as the [GitHub Actions is already locked into using v1.5.0.](https://github.com/iver-wharf/wharf-helm/blob/c95a6b3/.github/helm-docs.sh#L4)

- BREAKING: Changed image version of `providers.azuredevops` from v1.2.0 to v2.0.1.

- Changed image version of `web` from v1.3.3 to v1.4.0.

- Changed image version of `api` from v4.1.1 to v4.2.0.

## Motivation

Did a major version bump on the chart as the azuredevops update has breaking changes.
