### PR TITLE
Added new env var names

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,38 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.1.0
+
+- Added new environment variable mappings. The old ones are still applied. (#22)
+
+  - `api.ciUrl`: `WHARF_CI_TRIGGERURL` (was `CI_URL`)
+  - `api.ciToken`: `WHARF_CI_TRIGGERTOKEN` (was `CI_TOKEN`)
+  - `api.http.basicAuth`: `WHARF_HTTP_BASICAUTH` (was `BASIC_AUTH`)
+  - `api.http.bindAddress`: `WHARF_HTTP_BINDADDRESS` (was `BIND_ADDRESS`)
+  - `api.db.driver`: `WHARF_DB_DRIVER` (was `DBDRIVER`)
+  - `api.db.name`: `WHARF_DB_NAME` (was `DBNAME`)
+  - `api.db.username`: `WHARF_DB_USERNAME` (was `DBUSER`)
+  - `api.db.password`: `WHARF_DB_PASSWORD` (was `DBPASS`)
+  - `api.db.host`: `WHARF_DB_HOST` (was `DBHOST`)
+  - `api.db.port`: `WHARF_DB_PORT` (was `DBPORT`)
+  - `api.rabbitmq.enabled`: `WHARF_MQ_ENABLED` (was `RABBITMQENABLED`)
+  - `api.rabbitmq.username`: `WHARF_MQ_USERNAME` (was `RABBITMQUSER`)
+  - `api.rabbitmq.password`: `WHARF_MQ_PASSWORD` (was `RABBITMQPASS`)
+  - `api.rabbitmq.host`: `WHARF_MQ_HOST` (was `RABBITMQHOST`)
+  - `api.rabbitmq.port`: `WHARF_MQ_PORT` (was `RABBITMQPORT`)
+  - `api.rabbitmq.vHost`: `WHARF_MQ_VHOST` (was `RABBITMQVHOST`)
+  - `api.rabbitmq.name`: `WHARF_MQ_NAME` (was `RABBITMQNAME`)
+  - `api.rabbitmq.connAttempts`: `WHARF_MQ_CONNATTEMPTS` (was `RABBITMQCONNATTEMPTS`)
+
+- Added more environment variables for the Wharf API: (#22)
+
+  - `.Values.api.db.maxIdleConns`: `DBMAXIDLECONNS` & `WHARF_DB_MAXIDLECONNS`
+  - `.Values.api.db.maxOpenConns`: `DBMAXOPENCONNS` & `WHARF_DB_MAXOPENCONNS`
+  - `.Values.api.db.maxConnLifetime`: `DBMAXCONNLIFETIME` & `WHARF_DB_MAXCONNLIFETIME`
+
+- Added `WHARF_DB_LOG=false` environment variable to wharf-api service when
+  `.Values.global.isProduction` is set, which will suppress debug logs. (#22)
+
 ## v2.0.0
 
 - BREAKING: Changed image version of `providers.azuredevops` from v1.2.0 to

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 2.0.0
+version: 2.1.0
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -91,7 +91,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.db.maxConnLifetime`
 
-> Maximum age for a given database connection. If any connection exceeds this limit, while not it use, it will be disconnected. Sets `WHARF_DB_MAXCONNLIFETIME` environment variable. Value is a Go duration, see [Go docs](https://pkg.go.dev/time#ParseDuration). Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Maximum age for a given database connection. If any connection exceeds this limit, while not in use, it will be disconnected. Sets `WHARF_DB_MAXCONNLIFETIME` environment variable. Value is a Go duration, see [Go docs](https://pkg.go.dev/time#ParseDuration). Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"20m"`

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -49,14 +49,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.ciToken`
 
-> Jenkins webhook secret token used when starting new builds. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Jenkins webhook secret token used when starting new builds. Sets `WHARF_CI_TRIGGERTOKEN` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"changeit"`
 
 ### `api.ciUrl`
 
-> Jenkins webhook endpoint used when starting new builds. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Jenkins webhook endpoint used when starting new builds. Sets `WHARF_CI_TRIGGERURL` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"http://jenkins.example.com/generic-webhook-trigger/invoke"`
@@ -77,42 +77,63 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.db.driver`
 
-> Currently only `"postgres"` is a valid value here. Set to `null` or empty string `""` if you wish to populate the `DBHOST`, `DBPORT`, `DBUSER`, `DBPASS` environment variables yourself via `api.extraEnvs` Sets `DBDRIVER` environment variable. Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
+> Currently only `"postgres"` is a valid value here. Set to `null` or empty string `""` if you wish to populate the `WHARF_DB_HOST`, `WHARF_DB_PORT`, `WHARF_DB_USER`, `WHARF_DB_PASS` environment variables yourself via `api.extraEnvs`. Sets `WHARF_DB_DRIVER` environment variable. Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"postgres"`
 
 ### `api.db.host`
 
-> Database hostname used when connecting to the database. Sets `DBHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Database hostname used when connecting to the database. Sets `WHARF_DB_HOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"wharf-db"`
 
+### `api.db.maxConnLifetime`
+
+> Maximum age for a given database connection. If any connection exceeds this limit, while not it use, it will be disconnected. Sets `WHARF_DB_MAXCONNLIFETIME` environment variable. Value is a Go duration, see [Go docs](https://pkg.go.dev/time#ParseDuration). Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+
+*Type:* `string`\
+*Default:* `"20m"`
+
+### `api.db.maxIdleConns`
+
+> Maximum number of idle connections that wharf-api will use towards the database at a single point in time. Sets `WHARF_DB_MAXIDLECONNS` environment variable. ***(Integers must be quoted!)*** See [GORM docs](https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns). Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+
+*Type:* `string`\
+*Default:* `"2"`
+
+### `api.db.maxOpenConns`
+
+> Maximum number of open connections that wharf-api will use towards the database at a single point in time. Values <= 0 means no limit. Sets `WHARF_DB_MAXOPENCONNS` environment variable. ***(Integers must be quoted!)*** See [GORM docs](https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns). Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+
+*Type:* `string`\
+*Default:* `"0"`
+
 ### `api.db.name`
 
-> Name of the database (or "schema" in MySQL terms) holding all the tables. Sets `DBNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Name of the database (or "schema" in MySQL terms) holding all the tables. Sets `WHARF_DB_NAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"wharf"`
 
 ### `api.db.password`
 
-> Password used when connecting to the database. Sets `DBPASS` environment variable. Recommended to pull this from a secret. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Password used when connecting to the database. Sets `WHARF_DB_PASSWORD` environment variable. Recommended to pull this from a secret. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"changeit"`
 
 ### `api.db.port`
 
-> Database port used when connecting to the database. Sets `DBPORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Database port used when connecting to the database. Sets `WHARF_DB_PORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"5432"`
 
 ### `api.db.username`
 
-> Username used when connecting to the database. Sets `DBUSER` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Username used when connecting to the database. Sets `WHARF_DB_USERNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"postgres"`
@@ -126,14 +147,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.http.basicAuth`
 
-> Adds BasicAuth to the API. This is expiermental and is not automatically applied to the web, but only applied to the API. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Adds BasicAuth to the API. This is experimental and is not automatically applied to the web, but only applied to the API. Sets `WHARF_HTTP_BASICAUTH` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `""`
 
 ### `api.http.bindAddress`
 
-> Sets the IP address and port to bind the API server to. Sets `BIND_ADDRESS` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Sets the IP address and port to bind the API server to. Sets `WHARF_HTTP_BINDADDRESS` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"0.0.0.0:8080"`
@@ -175,7 +196,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.rabbitmq.connAttempts`
 
-> When the Wharf API starts up, how many times should it attempt to connect to the RabbitMQ instance before giving up and restarting? Sets `RABBITMQCONNATTEMPTS` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> When the Wharf API starts up, how many times should it attempt to connect to the RabbitMQ instance before giving up and restarting? Sets `WHARF_MQ_CONNATTEMPTS` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"10"`
@@ -196,35 +217,35 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.rabbitmq.name`
 
-> RabbitMQ queue name to push RabbitMQ messages into. Sets `RABBITMQNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> RabbitMQ queue name to push RabbitMQ messages into. Sets `WHARF_MQ_NAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"wharf_queue"`
 
 ### `api.rabbitmq.password`
 
-> Password used by Wharf to authenticate with RabbitMQ. Sets `RABBITMQPASS` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Password used by Wharf to authenticate with RabbitMQ. Sets `WHARF_MQ_PASSWORD` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"changeit"`
 
 ### `api.rabbitmq.port`
 
-> Host port used by Wharf to connect to RabbitMQ. Sets `RABBITMQPORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Host port used by Wharf to connect to RabbitMQ. Sets `WHARF_MQ_PORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"5672"`
 
 ### `api.rabbitmq.username`
 
-> Username used by Wharf to authenticate with RabbitMQ. Sets `RABBITMQUSER` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> Username used by Wharf to authenticate with RabbitMQ. Sets `WHARF_MQ_USERNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"user"`
 
 ### `api.rabbitmq.vHost`
 
-> RabbitMQ virtual host to push RabbitMQ messages into. Sets `RABBITMQVHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> RabbitMQ virtual host to push RabbitMQ messages into. Sets `WHARF_MQ_VHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"/"`
@@ -860,10 +881,10 @@ setting such as:
 
 ```yaml
 env:
-  - name: "DBHOST"
+  - name: "WHARF_DB_HOST"
     value: "my value"
 
-  - name: "DBHOST"
+  - name: "WHARF_DB_HOST"
     valueFrom:
       secretKeyRef:
         name: my-secret
@@ -885,7 +906,7 @@ api:
       value: "my value"
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    value: "my value"
 
     host:
@@ -895,7 +916,7 @@ api:
           key: my-key-in-the-secret
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    valueFrom:
     #      secretKeyRef:
     #        name: my-secret
@@ -904,7 +925,7 @@ api:
     host: "my value"
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    value: "my value"
 ```
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -217,7 +217,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `api.rabbitmq.name`
 
-> RabbitMQ queue name to push RabbitMQ messages into. Sets `WHARF_MQ_NAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+> RabbitMQ queue name to push RabbitMQ messages into. Sets `WHARF_MQ_QUEUENAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
 
 *Type:* `string`\
 *Default:* `"wharf_queue"`

--- a/charts/wharf-helm/README.md.gotmpl
+++ b/charts/wharf-helm/README.md.gotmpl
@@ -80,10 +80,10 @@ setting such as:
 
 ```yaml
 env:
-  - name: "DBHOST"
+  - name: "WHARF_DB_HOST"
     value: "my value"
 
-  - name: "DBHOST"
+  - name: "WHARF_DB_HOST"
     valueFrom:
       secretKeyRef:
         name: my-secret
@@ -105,7 +105,7 @@ api:
       value: "my value"
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    value: "my value"
 
     host:
@@ -115,7 +115,7 @@ api:
           key: my-key-in-the-secret
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    valueFrom:
     #      secretKeyRef:
     #        name: my-secret
@@ -124,7 +124,7 @@ api:
     host: "my value"
     # Would be added to the Pod's environment variables as:
     #env:
-    #  - name: DBHOST
+    #  - name: WHARF_DB_HOST
     #    value: "my value"
 ```
 

--- a/charts/wharf-helm/templates/_helpers.tpl
+++ b/charts/wharf-helm/templates/_helpers.tpl
@@ -101,3 +101,35 @@ Which will generate:
     value: {{ toYaml . -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Environment variable mapping.
+Takes a list as argument, where the first value is the environment value passed
+on to wharf-helm.environmentValue, while the rest are the environment names.
+
+Given the value:
+
+  host: exampleValue
+
+And the templating usage:
+
+  {{- list .host "DBHOST" "WHARF_DB_HOST" | include "wharf-helm.environment" | nindent 12 }}
+
+Which will generate:
+
+  - name: DBHOST
+    value: exampleValue
+  - name: WHARF_DB_HOST
+    value: exampleValue
+
+*/}}
+{{- define "wharf-helm.environment" -}}
+  {{- $value := first . -}}
+  {{- range $i, $envName := rest . -}}
+    {{- if gt $i 0 -}}
+      {{- printf "\n" -}}
+    {{- end -}}
+    - name: {{ $envName | quote }}
+    {{- $value | include "wharf-helm.environmentValue" | nindent 2 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -71,7 +71,7 @@ spec:
                 {{- list .host "RABBITMQHOST" "WHARF_MQ_HOST" | include "wharf-helm.environment" | nindent 12 }}
                 {{- list .port "RABBITMQPORT" "WHARF_MQ_PORT" | include "wharf-helm.environment" | nindent 12 }}
                 {{- list .vHost "RABBITMQVHOST" "WHARF_MQ_VHOST" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .name "RABBITMQNAME" "WHARF_MQ_NAME" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .name "RABBITMQNAME" "WHARF_MQ_QUEUENAME" | include "wharf-helm.environment" | nindent 12 }}
                 {{- list .connAttempts "RABBITMQCONNATTEMPTS" "WHARF_MQ_CONNATTEMPTS" | include "wharf-helm.environment" | nindent 12 }}
               {{- else }}
                 {{- list "false" "RABBITMQENABLED" "WHARF_MQ_ENABLED" | include "wharf-helm.environment" | nindent 12 }}

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -47,17 +47,15 @@ spec:
             {{- with .Values.global.instanceId }}
             - name: WHARF_INSTANCE
               value: {{ quote . }}
+            - name: WHARF_INSTANCEID
+              value: {{ quote . }}
             {{- end }}
-            - name: CI_URL
-              {{- .Values.api.ciUrl | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: CI_TOKEN
-              {{- .Values.api.ciToken | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- list .Values.api.ciUrl "CI_URL" "WHARF_CI_TRIGGERURL" | include "wharf-helm.environment" | nindent 12 }}
+            {{- list .Values.api.ciToken "CI_TOKEN" "WHARF_CI_TRIGGERTOKEN" | include "wharf-helm.environment" | nindent 12 }}
 
             {{- with .Values.api.http }}
-            - name: BASIC_AUTH
-              {{- .basicAuth | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: BIND_ADDRESS
-              {{- .bindAddress | include "wharf-helm.environmentValue" | nindent 14 }}
+              {{- list .bindAddress "BASIC_AUTH" "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .bindAddress "BIND_ADDRESS" "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}{{/* with .Values.api.http */}}
 
             {{- if .Values.global.isProduction }}
@@ -66,44 +64,37 @@ spec:
             {{- end }}
 
             {{- with .Values.api.rabbitmq }}
-            {{- if .enabled }}
-            - name: RABBITMQENABLED
-              value: "true"
-            - name: RABBITMQUSER
-              {{- .username | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQPASS
-              {{- .password | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQHOST
-              {{- .host | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQPORT
-              {{- .port | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQVHOST
-              {{- .vHost | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQNAME
-              {{- .name | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: RABBITMQCONNATTEMPTS
-              {{- .connAttempts | include "wharf-helm.environmentValue" | nindent 14 }}
-            {{- else }}
-            - name: RABBITMQENABLED
-              value: "false"
-            {{- end }}{{/* if .enabled */}}
+              {{- if .enabled }}
+                {{- list "true" "RABBITMQENABLED" "WHARF_MQ_ENABLED" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .username "RABBITMQUSER" "WHARF_MQ_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .password "RABBITMQPASS" "WHARF_MQ_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .host "RABBITMQHOST" "WHARF_MQ_HOST" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .port "RABBITMQPORT" "WHARF_MQ_PORT" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .vHost "RABBITMQVHOST" "WHARF_MQ_VHOST" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .name "RABBITMQNAME" "WHARF_MQ_NAME" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .connAttempts "RABBITMQCONNATTEMPTS" "WHARF_MQ_CONNATTEMPTS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- else }}
+                {{- list "false" "RABBITMQENABLED" "WHARF_MQ_ENABLED" | include "wharf-helm.environment" | nindent 12 }}
+              {{- end }}{{/* if .enabled */}}
             {{- end }}{{/* with .Values.api.rabbitmq */}}
 
             {{- with .Values.api.db }}
-            - name: DBDRIVER
-              {{- .driver | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: DBNAME
-              {{- .name | include "wharf-helm.environmentValue" | nindent 14 }}
-            {{- if eq .driver "postgres" }}
-            - name: DBUSER
-              {{- .username | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: DBPASS
-              {{- .password | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: DBPORT
-              {{- .port | include "wharf-helm.environmentValue" | nindent 14 }}
-            - name: DBHOST
-              {{- .host | include "wharf-helm.environmentValue" | nindent 14 }}
-            {{- end }}{{/* if .driver == "postgres" */}}
+              {{- if $.Values.global.isProduction }}
+                {{- list "false" "DBLOG" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
+              {{- else }}
+                {{- list "true" "DBLOG" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
+              {{- end }}{{/* if $.Values.global.isProduction */}}
+              {{- list .driver "DBDRIVER" "WHARF_DB_DRIVER" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .name "DBNAME" "WHARF_DB_NAME" | include "wharf-helm.environment" | nindent 12 }}
+              {{- if eq .driver "postgres" }}
+                {{- list .username "DBUSER" "WHARF_DB_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .password "DBPASS" "WHARF_DB_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .port "DBPORT" "WHARF_DB_PORT" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .host "DBHOST" "WHARF_DB_HOST" | include "wharf-helm.environment" | nindent 12 }}
+              {{- end }}{{/* if .driver == "postgres" */}}
+              {{- list .maxIdleConns "DBMAXIDLECONNS" "WHARF_DB_MAXIDLECONNS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .maxOpenConns "DBMAXOPENCONNS" "WHARF_DB_MAXOPENCONNS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .maxConnLifetime "DBMAXCONNLIFETIME" "WHARF_DB_MAXCONNLIFETIME" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}{{/* with .Values.api.db */}}
 
             {{- with .Values.api.extraEnvs }}

--- a/charts/wharf-helm/templates/provider.yaml
+++ b/charts/wharf-helm/templates/provider.yaml
@@ -79,8 +79,7 @@ spec:
             - name: WHARF_PROVIDER_URL_BASE
               value: {{ $providerUrlBase | quote }}
             {{- with $provider.http }}
-            - name: BIND_ADDRESS
-              {{- .bindAddress | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- list .bindAddress "BIND_ADDRESS" "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}
 
             {{- if $.Values.global.isProduction }}

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -170,9 +170,11 @@ api:
   containerPort: 8080
   
   # -- Jenkins webhook endpoint used when starting new builds.
+  # Sets `WHARF_CI_TRIGGERURL` environment variable.
   # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
   ciUrl: http://jenkins.example.com/generic-webhook-trigger/invoke
   # -- Jenkins webhook secret token used when starting new builds.
+  # Sets `WHARF_CI_TRIGGERTOKEN` environment variable.
   # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
   ciToken: changeit
   #ciToken:
@@ -182,37 +184,39 @@ api:
   #      key: webhook-token
 
   http:
-    # -- Adds BasicAuth to the API. This is expiermental and is not
+    # -- Adds BasicAuth to the API. This is experimental and is not
     # automatically applied to the web, but only applied to the API.
+    # Sets `WHARF_HTTP_BASICAUTH` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     basicAuth: ""
 
     # -- Sets the IP address and port to bind the API server to.
-    # Sets `BIND_ADDRESS` environment variable.
+    # Sets `WHARF_HTTP_BINDADDRESS` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     bindAddress: "0.0.0.0:8080"
 
   # Settings for Wharf API's database connection
   db:
     # -- Currently only `"postgres"` is a valid value here. Set to `null` or
-    # empty string `""` if you wish to populate the `DBHOST`, `DBPORT`,
-    # `DBUSER`, `DBPASS` environment variables yourself via `api.extraEnvs`
-    # Sets `DBDRIVER` environment variable.
+    # empty string `""` if you wish to populate the `WHARF_DB_HOST`,
+    # `WHARF_DB_PORT`, `WHARF_DB_USER`, `WHARF_DB_PASS` environment variables
+    # yourself via `api.extraEnvs`.
+    # Sets `WHARF_DB_DRIVER` environment variable.
     # Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
     driver: postgres
   
     # -- Name of the database (or "schema" in MySQL terms) holding all the
-    # tables. Sets `DBNAME` environment variable.
+    # tables. Sets `WHARF_DB_NAME` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     name: wharf
 
     # -- Username used when connecting to the database.
-    # Sets `DBUSER` environment variable.
+    # Sets `WHARF_DB_USERNAME` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     username: postgres
   
     # -- Password used when connecting to the database.
-    # Sets `DBPASS` environment variable.
+    # Sets `WHARF_DB_PASSWORD` environment variable.
     # Recommended to pull this from a secret.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     password: changeit
@@ -223,14 +227,36 @@ api:
     #      key: postgresql-password
 
     # -- Database hostname used when connecting to the database.
-    # Sets `DBHOST` environment variable.
+    # Sets `WHARF_DB_HOST` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     host: wharf-db
 
     # -- Database port used when connecting to the database.
-    # Sets `DBPORT` environment variable. ***(Integers must be quoted!)***
+    # Sets `WHARF_DB_PORT` environment variable. ***(Integers must be quoted!)***
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     port: "5432"
+
+    # -- Maximum number of idle connections that wharf-api will use towards the
+    # database at a single point in time.
+    # Sets `WHARF_DB_MAXIDLECONNS` environment variable.
+    # ***(Integers must be quoted!)***
+    # See [GORM docs](https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns).
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+    maxIdleConns: "2"
+
+    # -- Maximum number of open connections that wharf-api will use towards the
+    # database at a single point in time. Values <= 0 means no limit.
+    # Sets `WHARF_DB_MAXOPENCONNS` environment variable. ***(Integers must be quoted!)***
+    # See [GORM docs](https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns).
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+    maxOpenConns: "0"
+
+    # -- Maximum age for a given database connection. If any connection exceeds
+    # this limit, while not it use, it will be disconnected.
+    # Sets `WHARF_DB_MAXCONNLIFETIME` environment variable.
+    # Value is a Go duration, see [Go docs](https://pkg.go.dev/time#ParseDuration).
+    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
+    maxConnLifetime: 20m
 
   # Settings Wharf API's integration with RabbitMQ
   rabbitmq:
@@ -240,11 +266,11 @@ api:
     # Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
     enabled: false
     # -- Username used by Wharf to authenticate with RabbitMQ.
-    # Sets `RABBITMQUSER` environment variable.
+    # Sets `WHARF_MQ_USERNAME` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     username: user
     # -- Password used by Wharf to authenticate with RabbitMQ.
-    # Sets `RABBITMQPASS` environment variable.
+    # Sets `WHARF_MQ_PASSWORD` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     password: changeit
     #password:
@@ -253,24 +279,24 @@ api:
     #      name: rabbitmq-auth
     #      value: password
     # -- Host name *(without the protocol)* used by Wharf to connect to RabbitMQ.
-    # Sets `RABBITMQHOST` environment variable.
+    # Sets `WHARF_MQ_HOST` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     host: rabbitmq.local
     # -- Host port used by Wharf to connect to RabbitMQ.
-    # Sets `RABBITMQPORT` environment variable. ***(Integers must be quoted!)***
+    # Sets `WHARF_MQ_PORT` environment variable. ***(Integers must be quoted!)***
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     port: "5672"
     # -- RabbitMQ virtual host to push RabbitMQ messages into.
-    # Sets `RABBITMQVHOST` environment variable.
+    # Sets `WHARF_MQ_VHOST` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     vHost: /
     # -- RabbitMQ queue name to push RabbitMQ messages into.
-    # Sets `RABBITMQNAME` environment variable.
+    # Sets `WHARF_MQ_NAME` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     name: wharf_queue
     # -- When the Wharf API starts up, how many times should it attempt to connect
     # to the RabbitMQ instance before giving up and restarting?
-    # Sets `RABBITMQCONNATTEMPTS` environment variable.
+    # Sets `WHARF_MQ_CONNATTEMPTS` environment variable.
     # ***(Integers must be quoted!)***
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     connAttempts: "10"
@@ -280,13 +306,13 @@ api:
   # database connection here.
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
-    #- name: DBHOST
+    #- name: WHARF_DB_HOST
     #  value: wharf-db
-    #- name: DBPORT
+    #- name: WHARF_DB_PORT
     #  value: "5432"
-    #- name: DBUSER
+    #- name: WHARF_DB_USER
     #  value: postgres
-    #- name: DBPASS
+    #- name: WHARF_DB_PASS
     #  value: changeit
 
 # Provider settings. You are free to add more providers here. This is done by

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -291,7 +291,7 @@ api:
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     vHost: /
     # -- RabbitMQ queue name to push RabbitMQ messages into.
-    # Sets `WHARF_MQ_NAME` environment variable.
+    # Sets `WHARF_MQ_QUEUENAME` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     name: wharf_queue
     # -- When the Wharf API starts up, how many times should it attempt to connect

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -252,7 +252,7 @@ api:
     maxOpenConns: "0"
 
     # -- Maximum age for a given database connection. If any connection exceeds
-    # this limit, while not it use, it will be disconnected.
+    # this limit, while not in use, it will be disconnected.
     # Sets `WHARF_DB_MAXCONNLIFETIME` environment variable.
     # Value is a Go duration, see [Go docs](https://pkg.go.dev/time#ParseDuration).
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Added new helper definition, `wharf-helm.environment`, which writes out the environment variable name(s) as well as the value, and supports multiple names.

- Added new environment variable names for wharf-api, taken from the config: <https://github.com/iver-wharf/wharf-api/blob/v4.2.0/config.go>

## Motivation

The old env var names has been deprecated for a while now. This changes wharf-helm to use both the old and the new names.

Closes #21
