### PR TITLE
Fixed bindAddress reuse

### DIFF
--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 2.1.0
+version: 2.1.1
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -54,7 +54,7 @@ spec:
             {{- list .Values.api.ciToken "CI_TOKEN" "WHARF_CI_TRIGGERTOKEN" | include "wharf-helm.environment" | nindent 12 }}
 
             {{- with .Values.api.http }}
-              {{- list .bindAddress "BASIC_AUTH" "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .basicAuth "BASIC_AUTH" "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
               {{- list .bindAddress "BIND_ADDRESS" "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}{{/* with .Values.api.http */}}
 


### PR DESCRIPTION
- \[ ] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Fixed environment variable reuse. A typical "oopsie" from #22

## Motivation

Setting the `api.bindAddress` also sets a username+password via BasicAuth. With the default `values.yaml`, it sets `username=0.0.0.0` and `password=8080`.
