### PR TITLE
Updated wharf-provider-gitlab to v1.3.0

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.1.3
+
+- Changed image version of provider `gitlab` from v1.2.0 to v1.3.0. (#25)
+
 ## v2.1.2
 
 - Changed image version of `web` from v1.4.0 to v1.5.0. (#24)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 2.1.2
+version: 2.1.3
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -35,7 +35,7 @@ helm install my-release iver-wharf/wharf-helm
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.2.0](https://img.shields.io/badge/Version-v4.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.2.0"`
 | [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.0](https://img.shields.io/badge/Version-v1.5.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.0"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
-| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.2.0](https://img.shields.io/badge/Version-v1.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
+| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
 ## Values
@@ -724,7 +724,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `gitlab` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
 
 ### `providers.gitlab.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -461,7 +461,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `gitlab` provider
-    image: quay.io/iver-wharf/wharf-provider-gitlab:v1.2.0
+    image: quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0
     # -- Default image pull policy used in the `gitlab` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the GitLab provider


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Changed wharf-provider-gitlab from v1.2.0 to v1.3.0

## Motivation

[wharf-provider-gitlab v1.3.0](https://github.com/iver-wharf/wharf-provider-gitlab/releases/tag/v1.3.0) was just released. This updates the Helm chart to use the latest version.
