### PR TITLE
Updated wharf-web to v1.5.1 & artifacthub metadata

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -16,6 +16,7 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 ## v2.1.4
 
 - Changed image version of `web` from v1.5.0 to v1.5.1. (#26)
+- Added ArtifactHub annotations to Chart.yaml. (#26)
 
 ## v2.1.3
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.1.4
+
+- Changed image version of `web` from v1.5.0 to v1.5.1. (#26)
+
 ## v2.1.3
 
 - Changed image version of provider `gitlab` from v1.2.0 to v1.3.0. (#25)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 2.1.3
+version: 2.1.4
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -6,4 +6,9 @@ version: 2.1.4
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr
-    email: kalle.jillheden@iver.se
+    email: kalle.fagerberg@iver.se
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/iver-wharf/wharf-helm/issues/new

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square)
+![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -33,7 +33,7 @@ helm install my-release iver-wharf/wharf-helm
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.2.0](https://img.shields.io/badge/Version-v4.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.2.0"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.0](https://img.shields.io/badge/Version-v1.5.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.0"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.1](https://img.shields.io/badge/Version-v1.5.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.1"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
@@ -787,7 +787,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.5.0"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.5.1"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.5.0
+  image: quay.io/iver-wharf/wharf-web:v1.5.1
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Changed wharf-web from v1.5.0 to v1.5.1 ([release notes](https://github.com/iver-wharf/wharf-web/releases/tag/v1.5.1))

- Added ArtifactHub annotations for license and support URL https://artifacthub.io/docs/topics/annotations/helm/

## Motivation

One of the bug fixes in v1.5.1 is strongly wanted, namely:

> - Fixed version panel misplacement on scrollable pages and being locked to the width of the side nav bar, a bug introduced in v1.5.0 by [#82](https://github.com/iver-wharf/wharf-web/pull/82). ([#97](https://github.com/iver-wharf/wharf-web/pull/97))
