### PR TITLE
wharf-api v5 support

### DIFF
--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 2.1.4
+version: 3.0.0
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -32,7 +32,7 @@ helm install my-release iver-wharf/wharf-helm
 
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
-| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v4.2.0](https://img.shields.io/badge/Version-v4.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v4.2.0"`
+| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.0.0](https://img.shields.io/badge/Version-v5.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.0.0"`
 | [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.1](https://img.shields.io/badge/Version-v1.5.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.1"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
@@ -164,7 +164,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-api:v4.2.0"`
+*Default:* `"quay.io/iver-wharf/wharf-api:v5.0.0"`
 
 ### `api.imagePullPolicy`
 
@@ -193,62 +193,6 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `object`\
 *Default:* `{}`
-
-### `api.rabbitmq.connAttempts`
-
-> When the Wharf API starts up, how many times should it attempt to connect to the RabbitMQ instance before giving up and restarting? Sets `WHARF_MQ_CONNATTEMPTS` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"10"`
-
-### `api.rabbitmq.enabled`
-
-> `true` to enable RabbitMQ integration, `false` to disable it. All other `api.rabbitmq...` settings are ignored if RabbitMQ has been disabled. Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `bool`\
-*Default:* `false`
-
-### `api.rabbitmq.host`
-
->
-
-*Type:* `string`\
-*Default:* `"rabbitmq.local"`
-
-### `api.rabbitmq.name`
-
-> RabbitMQ queue name to push RabbitMQ messages into. Sets `WHARF_MQ_QUEUENAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"wharf_queue"`
-
-### `api.rabbitmq.password`
-
-> Password used by Wharf to authenticate with RabbitMQ. Sets `WHARF_MQ_PASSWORD` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"changeit"`
-
-### `api.rabbitmq.port`
-
-> Host port used by Wharf to connect to RabbitMQ. Sets `WHARF_MQ_PORT` environment variable. ***(Integers must be quoted!)*** Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"5672"`
-
-### `api.rabbitmq.username`
-
-> Username used by Wharf to authenticate with RabbitMQ. Sets `WHARF_MQ_USERNAME` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"user"`
-
-### `api.rabbitmq.vHost`
-
-> RabbitMQ virtual host to push RabbitMQ messages into. Sets `WHARF_MQ_VHOST` environment variable. Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-
-*Type:* `string`\
-*Default:* `"/"`
 
 ### `api.readinessProbe`
 

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -45,17 +45,15 @@ spec:
           {{- end }}
           env:
             {{- with .Values.global.instanceId }}
-            - name: WHARF_INSTANCE
-              value: {{ quote . }}
             - name: WHARF_INSTANCEID
               value: {{ quote . }}
             {{- end }}
-            {{- list .Values.api.ciUrl "CI_URL" "WHARF_CI_TRIGGERURL" | include "wharf-helm.environment" | nindent 12 }}
-            {{- list .Values.api.ciToken "CI_TOKEN" "WHARF_CI_TRIGGERTOKEN" | include "wharf-helm.environment" | nindent 12 }}
+            {{- list .Values.api.ciUrl "WHARF_CI_TRIGGERURL" | include "wharf-helm.environment" | nindent 12 }}
+            {{- list .Values.api.ciToken "WHARF_CI_TRIGGERTOKEN" | include "wharf-helm.environment" | nindent 12 }}
 
             {{- with .Values.api.http }}
-              {{- list .basicAuth "BASIC_AUTH" "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .bindAddress "BIND_ADDRESS" "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .basicAuth "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .bindAddress "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}{{/* with .Values.api.http */}}
 
             {{- if .Values.global.isProduction }}
@@ -65,21 +63,21 @@ spec:
 
             {{- with .Values.api.db }}
               {{- if $.Values.global.isProduction }}
-                {{- list "false" "DBLOG" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list "false" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
               {{- else }}
-                {{- list "true" "DBLOG" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list "true" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
               {{- end }}{{/* if $.Values.global.isProduction */}}
-              {{- list .driver "DBDRIVER" "WHARF_DB_DRIVER" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .name "DBNAME" "WHARF_DB_NAME" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .driver "WHARF_DB_DRIVER" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .name "WHARF_DB_NAME" | include "wharf-helm.environment" | nindent 12 }}
               {{- if eq .driver "postgres" }}
-                {{- list .username "DBUSER" "WHARF_DB_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .password "DBPASS" "WHARF_DB_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .port "DBPORT" "WHARF_DB_PORT" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .host "DBHOST" "WHARF_DB_HOST" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .username "WHARF_DB_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .password "WHARF_DB_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .port "WHARF_DB_PORT" | include "wharf-helm.environment" | nindent 12 }}
+                {{- list .host "WHARF_DB_HOST" | include "wharf-helm.environment" | nindent 12 }}
               {{- end }}{{/* if .driver == "postgres" */}}
-              {{- list .maxIdleConns "DBMAXIDLECONNS" "WHARF_DB_MAXIDLECONNS" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .maxOpenConns "DBMAXOPENCONNS" "WHARF_DB_MAXOPENCONNS" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .maxConnLifetime "DBMAXCONNLIFETIME" "WHARF_DB_MAXCONNLIFETIME" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .maxIdleConns "WHARF_DB_MAXIDLECONNS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .maxOpenConns "WHARF_DB_MAXOPENCONNS" | include "wharf-helm.environment" | nindent 12 }}
+              {{- list .maxConnLifetime "WHARF_DB_MAXCONNLIFETIME" | include "wharf-helm.environment" | nindent 12 }}
             {{- end }}{{/* with .Values.api.db */}}
 
             {{- with .Values.api.extraEnvs }}

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -63,21 +63,6 @@ spec:
               value: release
             {{- end }}
 
-            {{- with .Values.api.rabbitmq }}
-              {{- if .enabled }}
-                {{- list "true" "RABBITMQENABLED" "WHARF_MQ_ENABLED" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .username "RABBITMQUSER" "WHARF_MQ_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .password "RABBITMQPASS" "WHARF_MQ_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .host "RABBITMQHOST" "WHARF_MQ_HOST" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .port "RABBITMQPORT" "WHARF_MQ_PORT" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .vHost "RABBITMQVHOST" "WHARF_MQ_VHOST" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .name "RABBITMQNAME" "WHARF_MQ_QUEUENAME" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .connAttempts "RABBITMQCONNATTEMPTS" "WHARF_MQ_CONNATTEMPTS" | include "wharf-helm.environment" | nindent 12 }}
-              {{- else }}
-                {{- list "false" "RABBITMQENABLED" "WHARF_MQ_ENABLED" | include "wharf-helm.environment" | nindent 12 }}
-              {{- end }}{{/* if .enabled */}}
-            {{- end }}{{/* with .Values.api.rabbitmq */}}
-
             {{- with .Values.api.db }}
               {{- if $.Values.global.isProduction }}
                 {{- list "false" "DBLOG" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -48,12 +48,16 @@ spec:
             - name: WHARF_INSTANCEID
               value: {{ quote . }}
             {{- end }}
-            {{- list .Values.api.ciUrl "WHARF_CI_TRIGGERURL" | include "wharf-helm.environment" | nindent 12 }}
-            {{- list .Values.api.ciToken "WHARF_CI_TRIGGERTOKEN" | include "wharf-helm.environment" | nindent 12 }}
+            - name: WHARF_CI_TRIGGERURL
+              {{- .Values.api.ciUrl | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_CI_TRIGGERTOKEN
+              {{- .Values.api.ciToken | include "wharf-helm.environmentValue" | nindent 14 }}
 
             {{- with .Values.api.http }}
-              {{- list .basicAuth "WHARF_HTTP_BASICAUTH" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .bindAddress "WHARF_HTTP_BINDADDRESS" | include "wharf-helm.environment" | nindent 12 }}
+            - name: WHARF_HTTP_BASICAUTH
+              {{- .basicAuth | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_HTTP_BINDADDRESS
+              {{- .bindAddress | include "wharf-helm.environmentValue" | nindent 14 }}
             {{- end }}{{/* with .Values.api.http */}}
 
             {{- if .Values.global.isProduction }}
@@ -62,22 +66,33 @@ spec:
             {{- end }}
 
             {{- with .Values.api.db }}
-              {{- if $.Values.global.isProduction }}
-                {{- list "false" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
-              {{- else }}
-                {{- list "true" "WHARF_DB_LOG" | include "wharf-helm.environment" | nindent 12 }}
-              {{- end }}{{/* if $.Values.global.isProduction */}}
-              {{- list .driver "WHARF_DB_DRIVER" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .name "WHARF_DB_NAME" | include "wharf-helm.environment" | nindent 12 }}
-              {{- if eq .driver "postgres" }}
-                {{- list .username "WHARF_DB_USERNAME" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .password "WHARF_DB_PASSWORD" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .port "WHARF_DB_PORT" | include "wharf-helm.environment" | nindent 12 }}
-                {{- list .host "WHARF_DB_HOST" | include "wharf-helm.environment" | nindent 12 }}
-              {{- end }}{{/* if .driver == "postgres" */}}
-              {{- list .maxIdleConns "WHARF_DB_MAXIDLECONNS" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .maxOpenConns "WHARF_DB_MAXOPENCONNS" | include "wharf-helm.environment" | nindent 12 }}
-              {{- list .maxConnLifetime "WHARF_DB_MAXCONNLIFETIME" | include "wharf-helm.environment" | nindent 12 }}
+            {{- if $.Values.global.isProduction }}
+            - name: WHARF_DB_LOG
+              {{- "false" | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- else }}
+            - name: WHARF_DB_LOG
+              {{- "true" | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- end }}{{/* if $.Values.global.isProduction */}}
+            - name: WHARF_DB_DRIVER
+              {{- .driver | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_NAME
+              {{- .name | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- if eq .driver "postgres" }}
+            - name: WHARF_DB_USERNAME
+              {{- .username | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_PASSWORD
+              {{- .password | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_PORT
+              {{- .port | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_HOST
+              {{- .host | include "wharf-helm.environmentValue" | nindent 14 }}
+            {{- end }}{{/* if .driver == "postgres" */}}
+            - name: WHARF_DB_MAXIDLECONNS
+              {{- .maxIdleConns | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_MAXOPENCONNS
+              {{- .maxOpenConns | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_DB_MAXCONNLIFETIME
+              {{- .maxConnLifetime | include "wharf-helm.environmentValue" | nindent 14 }}
             {{- end }}{{/* with .Values.api.db */}}
 
             {{- with .Values.api.extraEnvs }}

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -258,50 +258,6 @@ api:
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     maxConnLifetime: 20m
 
-  # Settings Wharf API's integration with RabbitMQ
-  rabbitmq:
-    # -- `true` to enable RabbitMQ integration, `false` to disable it.
-    # All other `api.rabbitmq...` settings are ignored if RabbitMQ has been
-    # disabled.
-    # Does not support ["Smart environment fields"](./README.md#smart-environment-fields)
-    enabled: false
-    # -- Username used by Wharf to authenticate with RabbitMQ.
-    # Sets `WHARF_MQ_USERNAME` environment variable.
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    username: user
-    # -- Password used by Wharf to authenticate with RabbitMQ.
-    # Sets `WHARF_MQ_PASSWORD` environment variable.
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    password: changeit
-    #password:
-    #  valueFrom:
-    #    secretKeyRef:
-    #      name: rabbitmq-auth
-    #      value: password
-    # -- Host name *(without the protocol)* used by Wharf to connect to RabbitMQ.
-    # Sets `WHARF_MQ_HOST` environment variable.
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    host: rabbitmq.local
-    # -- Host port used by Wharf to connect to RabbitMQ.
-    # Sets `WHARF_MQ_PORT` environment variable. ***(Integers must be quoted!)***
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    port: "5672"
-    # -- RabbitMQ virtual host to push RabbitMQ messages into.
-    # Sets `WHARF_MQ_VHOST` environment variable.
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    vHost: /
-    # -- RabbitMQ queue name to push RabbitMQ messages into.
-    # Sets `WHARF_MQ_QUEUENAME` environment variable.
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    name: wharf_queue
-    # -- When the Wharf API starts up, how many times should it attempt to connect
-    # to the RabbitMQ instance before giving up and restarting?
-    # Sets `WHARF_MQ_CONNATTEMPTS` environment variable.
-    # ***(Integers must be quoted!)***
-    # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
-    connAttempts: "10"
-
-
   # -- If `api.db.driver` is unset, then you must populate your own
   # database connection here.
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -106,7 +106,7 @@ api:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-api:v4.2.0
+  image: quay.io/iver-wharf/wharf-api:v5.0.0
   
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)

## Summary

- Dropped RabbitMQ settings
- Changed api image to v5.0.0
- Removed old env vars
- Changed back to using wharf-helm.environmentValue template
- Updated docs
- Drops support for wharf-api v4 and younger

## Motivation

Stay up to date and clean up the chart.
