### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: helm-docs deps \
+	lint lint-md lint-helm \
+	lint-fix lint-md-fix
+
+helm-docs:
+	helm-docs
+
+deps:
+	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.5.0
+	npm install
+
+lint: lint-md lint-helm
+lint-fix: lint-md-fix
+
+lint-md:
+	npx remark . .github
+
+lint-md-fix:
+	npx remark . .github -o
+
+lint-helm:
+	helm lint charts/wharf-helm

--- a/README.md
+++ b/README.md
@@ -57,18 +57,25 @@ Once you're ready to deploy it you create a pull request from that release
 branch over to `master`, where it will be published automatically as soon as
 it's merged.
 
-## Linting markdown
+## Linting
 
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
+You can lint all of the above at the same time by running:
 
 ```sh
-npm install
+make lint
 
-npm run lint-md
+make lint-helm # only lint Helm charts
+make lint-md # only lint Markdown files
+```
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-helm # Helm linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,8 +1,4 @@
 {
-  "scripts": {
-    "lint": "remark . .github",
-    "lint-fix": "remark . .github -o"
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting and other utilities like helm-docs
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
