### PR TITLE
Fixed lint-fix Makefile targets ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: helm-docs deps \
 	lint lint-md lint-helm \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md
 
 helm-docs:
 	helm-docs
@@ -10,12 +10,12 @@ deps:
 	npm install
 
 lint: lint-md lint-helm
-lint-fix: lint-md-fix
+lint-fix: lint-fix-md
 
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o
 
 lint-helm:

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ it's merged.
 
 ## Linting
 
-You can lint all of the above at the same time by running:
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-helm # only lint Helm charts


### PR DESCRIPTION
## Summary

- Renamed Makefile targets from `lint-{lang}-fix` to `lint-fix-{lang}` to stay consistent with the README.md

## Motivation

Having the lang part last makes most sense to me as it lets the most specific part be last in the string, sort of like reverse domain names.
