### PR TITLE
Removed v1.1.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -206,17 +206,4 @@ entries:
     urls:
     - https://github.com/iver-wharf/wharf-helm/releases/download/wharf-helm-1.1.1/wharf-helm-1.1.1.tgz
     version: 1.1.1
-  - apiVersion: v2
-    created: "2021-05-28T15:24:03.296902537Z"
-    description: Deploy Wharf to Kubernetes
-    digest: 1a672b613a0e845c70daf6b9f3cecb04b4bb5f82c394c369aabf4ed85ba2c247
-    home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
-    maintainers:
-    - email: kalle.jillheden@iver.se
-      name: jilleJr
-    name: wharf-helm
-    type: application
-    urls:
-    - https://github.com/iver-wharf/wharf-helm/releases/download/wharf-helm-1.1.0/wharf-helm-1.1.0.tgz
-    version: 1.1.0
-generated: "2022-02-15T15:29:56.441095629Z"
+generated: "2022-02-16T06:29:42.154082393Z"


### PR DESCRIPTION
## Summary

- Removed wharf-helm-1.1.0 release from index.yaml.
- Plan to remove [wharf-helm-1.1.0](https://github.com/iver-wharf/wharf-helm/releases/tag/wharf-helm-1.1.0) release from GitHub releases once merged.

## Motivation

I get these emails about once a week from ArtifactHub where it tries to scan
all of our releases, but fails on v1.1.0 of the wharf-helm chart:

> We encountered some errors while scanning the packages in repository wharf-helm for security vulnerabilities.
>
> **Errors log**
> `error scanning image harbor.local/tools/wharf-project/api:v3.0.0: error running trivy on image harbor.local/tools/wharf-project/api:v3.0.0: * Get "https://harbor.local/v2/": dial tcp: lookup harbor.local on 10.100.0.10:53: no such host; Get "http://harbor.local/v2/": dial tcp: lookup harbor.local on 10.100.0.10:53: no such host (package wharf-helm:1.1.0)`

This is because we didn't host our package on quay.io until v1.1.1, as can be seen here:

- wharf-helm-1.1.0 (commit 819db7f00e84a48a06ba025ccfc6b1b445fc2bb6), using harbor.local: https://github.com/iver-wharf/wharf-helm/blob/819db7f00e84a48a06ba025ccfc6b1b445fc2bb6/charts/wharf-helm/values.yaml#L18
- wharf-helm-1.1.1 (commit d4743a9b60c144cfff63e1de66be2b8e5a82dcd5), using quay.io: https://github.com/iver-wharf/wharf-helm/blob/d4743a9b60c144cfff63e1de66be2b8e5a82dcd5/charts/wharf-helm/values.yaml#L18

Plan is to remove the release from the index, and remove the Git tag and GitHub release <https://github.com/iver-wharf/wharf-helm/releases/tag/wharf-helm-1.1.0> to not let ArtifactHub get confused.

I've not found a way to omit a certain version to be vulnerability-scanned in ArtifactHub. It's pretty much a requirement it seems.
