### PR TITLE
Add web OIDC config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 - \[ ] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
   https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
   (but without version dates nor WIP versions)
+- \[ ] I've version bumped `charts/wharf-helm/Chart.yml`
 
 ## Summary
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -15,7 +15,7 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v3.0.1
 
-- Add oidc config values for Web. (#31)
+- Added OIDC config values for Web. (#31)
 
 ## v3.0.0
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -15,7 +15,8 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v3.1.0
 
-- Added OIDC config values for Web. (#31)
+- Added OIDC config values for Web via the new `web.oidcEnabled` and
+  `web.oidc.*` values. (#31)
 
 ## v3.0.0
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,7 +13,7 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.0.1
+## v3.1.0
 
 - Added OIDC config values for Web. (#31)
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.0.1
+
+- Add oidc config values for Web. (#31)
+
 ## v3.0.0
 
 - BREAKING: Removes support for wharf-api v4.x.x and older.

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.0.1
+version: 3.1.0
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.0.0
+version: 3.0.1
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -158,76 +158,6 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `string`\
 *Default:* `"0.0.0.0:8080"`
-
-### `api.http.oidc.authority`
-
-> The url to the Security Token Service (STS). The authority issues tokens. This field is required.
-
-*Type:* `string`\
-*Default:* `"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"`
-
-### `api.http.oidc.clientId`
-
-> The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
-
-*Type:* `string`\
-*Default:* `"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"`
-
-### `api.http.oidc.ignoreNonceAfterRefresh`
-
-> A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
-
-*Type:* `bool`\
-*Default:* `true`
-
-### `api.http.oidc.logLevel`
-
-> 0, 1, 2 can be used to set the log level displayed in the console.
-
-*Type:* `string`\
-*Default:* `"debug"`
-
-### `api.http.oidc.maxIdTokenIatOffsetAllowedInSeconds`
-
-> Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
-
-*Type:* `int`\
-*Default:* `600`
-
-### `api.http.oidc.postLogoutRedirectUri`
-
-> URL to redirect to after a server logout if using the end session API.
-
-*Type:* `string`\
-*Default:* `"https://wharf.stage.atlas.dgc.local"`
-
-### `api.http.oidc.redirectUrl`
-
-> The redirect URL defined on the Security Token Service.
-
-*Type:* `string`\
-*Default:* `"https://wharf.stage.atlas.dgc.local"`
-
-### `api.http.oidc.scope`
-
-> List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
-
-*Type:* `string`\
-*Default:* `"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"`
-
-### `api.http.oidc.silentRenew`
-
-> Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
-
-*Type:* `bool`\
-*Default:* `true`
-
-### `api.http.oidc.useRefreshToken`
-
-> When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
-
-*Type:* `bool`\
-*Default:* `true`
 
 ### `api.image`
 
@@ -823,6 +753,69 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `object`\
 *Default:* `{"kubernetes.io/os":"linux"}`
+
+### `web.oidc`
+
+> Settings for the OpenId Connect authentication login.
+
+*Type:* `object`\
+*Default:* `{"authority":"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration","clientId":"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779","ignoreNonceAfterRefresh":true,"logLevel":"debug","maxIdTokenIatOffsetAllowedInSeconds":600,"scope":"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy","silentRenew":true,"useRefreshToken":true}`
+
+### `web.oidc.authority`
+
+> The url to the Security Token Service (STS). The authority issues tokens. This field is required.
+
+*Type:* `string`\
+*Default:* `"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"`
+
+### `web.oidc.clientId`
+
+> The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
+
+*Type:* `string`\
+*Default:* `"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"`
+
+### `web.oidc.ignoreNonceAfterRefresh`
+
+> A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
+
+*Type:* `bool`\
+*Default:* `true`
+
+### `web.oidc.logLevel`
+
+> 0, 1, 2 can be used to set the log level displayed in the console.
+
+*Type:* `string`\
+*Default:* `"debug"`
+
+### `web.oidc.maxIdTokenIatOffsetAllowedInSeconds`
+
+> Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
+
+*Type:* `int`\
+*Default:* `600`
+
+### `web.oidc.scope`
+
+> List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
+
+*Type:* `string`\
+*Default:* `"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"`
+
+### `web.oidc.silentRenew`
+
+> Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
+
+*Type:* `bool`\
+*Default:* `true`
+
+### `web.oidc.useRefreshToken`
+
+> When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
+
+*Type:* `bool`\
+*Default:* `true`
 
 ### `web.podSecurityContext`
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -756,66 +756,17 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `web.oidc`
 
-> Settings for the OpenId Connect authentication login.
+> Settings for the OpenId Connect authentication login. These are the config values for the angular-auth-oidc-client NPM package that wharf-web uses. The `web.oidc.redirectUrl` and `web.oidc.postLogoutRedirectUri` defaults to the `global.url` Helm value prefixed with `https://`. See documentation on configs here: https://nice-hill-002425310.azurestaticapps.net/docs/documentation/configuration#config-values See source code for configs here: https://github.com/damienbod/angular-auth-oidc-client/blob/release_13_1_0/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts Note: These configs are ignored unless `web.oidcEnabled` is set to `true`.
 
 *Type:* `object`\
-*Default:* `{"authority":"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration","clientId":"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779","ignoreNonceAfterRefresh":true,"logLevel":"debug","maxIdTokenIatOffsetAllowedInSeconds":600,"scope":"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy","silentRenew":true,"useRefreshToken":true}`
+*Default:* `{"authority":"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration","autoUserInfo":false,"clientId":"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779","ignoreNonceAfterRefresh":true,"issValidationOff":false,"logLevel":2,"maxIdTokenIatOffsetAllowedInSeconds":600,"postLogoutRedirectUri":null,"redirectUrl":null,"responseType":"id_token token","scope":"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy","silentRenew":true,"useRefreshToken":true}`
 
-### `web.oidc.authority`
+### `web.oidcEnabled`
 
-> The url to the Security Token Service (STS). The authority issues tokens. This field is required.
-
-*Type:* `string`\
-*Default:* `"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"`
-
-### `web.oidc.clientId`
-
-> The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
-
-*Type:* `string`\
-*Default:* `"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"`
-
-### `web.oidc.ignoreNonceAfterRefresh`
-
-> A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
+> If this is `false` or unset then no OIDC configs will be applied.
 
 *Type:* `bool`\
-*Default:* `true`
-
-### `web.oidc.logLevel`
-
-> 0, 1, 2 can be used to set the log level displayed in the console.
-
-*Type:* `string`\
-*Default:* `"debug"`
-
-### `web.oidc.maxIdTokenIatOffsetAllowedInSeconds`
-
-> Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
-
-*Type:* `int`\
-*Default:* `600`
-
-### `web.oidc.scope`
-
-> List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
-
-*Type:* `string`\
-*Default:* `"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"`
-
-### `web.oidc.silentRenew`
-
-> Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
-
-*Type:* `bool`\
-*Default:* `true`
-
-### `web.oidc.useRefreshToken`
-
-> When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
-
-*Type:* `bool`\
-*Default:* `true`
+*Default:* `false`
 
 ### `web.podSecurityContext`
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,7 +1,7 @@
 # Wharf Helm chart
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) 
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
 
@@ -39,7 +39,6 @@ helm install my-release iver-wharf/wharf-helm
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
 ## Values
-
 
 ### `api.affinity`
 
@@ -337,21 +336,21 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `imagePullSecrets`
 
-> 
+>
 
 *Type:* `list`\
 *Default:* `[]`
 
 ### `ingress.annotations`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingress.apiVersion`
 
-> 
+>
 
 *Type:* `string`\
 *Default:* `"networking.k8s.io/v1beta1"`
@@ -372,14 +371,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingress.tls`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingressRoute.apiVersion`
 
-> 
+>
 
 *Type:* `string`\
 *Default:* `"traefik.containo.us/v1alpha1"`
@@ -393,7 +392,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[0].annotations`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
@@ -421,14 +420,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[0].tls`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingressRoute.entries[1].annotations`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
@@ -442,7 +441,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[1].middlewares`
 
-> 
+>
 
 *Type:* `list`\
 *Default:* `[]`
@@ -456,7 +455,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[1].tls.secretName`
 
-> 
+>
 
 *Type:* `string`\
 *Default:* `"wharf-example-tls"`
@@ -582,7 +581,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `providers.example.imagePullSecrets`
 
-> 
+>
 
 *Type:* `list`\
 *Default:* `[]`
@@ -617,7 +616,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `providers.example.podAnnotations`
 
-> 
+>
 
 *Type:* `object`\
 *Default:* `{}`
@@ -887,7 +886,6 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `list`\
 *Default:* `[{"emptyDir":{},"name":"cache"},{"emptyDir":{},"name":"run"}]`
-
 
 ## Smart environment fields
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,7 +1,7 @@
 # Wharf Helm chart
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square)
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) 
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) 
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
 
@@ -39,6 +39,7 @@ helm install my-release iver-wharf/wharf-helm
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
 ## Values
+
 
 ### `api.affinity`
 
@@ -159,6 +160,76 @@ helm install my-release iver-wharf/wharf-helm
 *Type:* `string`\
 *Default:* `"0.0.0.0:8080"`
 
+### `api.http.oidc.authority`
+
+> The url to the Security Token Service (STS). The authority issues tokens. This field is required.
+
+*Type:* `string`\
+*Default:* `"https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"`
+
+### `api.http.oidc.clientId`
+
+> The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
+
+*Type:* `string`\
+*Default:* `"01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"`
+
+### `api.http.oidc.ignoreNonceAfterRefresh`
+
+> A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
+
+*Type:* `bool`\
+*Default:* `true`
+
+### `api.http.oidc.logLevel`
+
+> 0, 1, 2 can be used to set the log level displayed in the console.
+
+*Type:* `string`\
+*Default:* `"debug"`
+
+### `api.http.oidc.maxIdTokenIatOffsetAllowedInSeconds`
+
+> Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
+
+*Type:* `int`\
+*Default:* `600`
+
+### `api.http.oidc.postLogoutRedirectUri`
+
+> URL to redirect to after a server logout if using the end session API.
+
+*Type:* `string`\
+*Default:* `"https://wharf.stage.atlas.dgc.local"`
+
+### `api.http.oidc.redirectUrl`
+
+> The redirect URL defined on the Security Token Service.
+
+*Type:* `string`\
+*Default:* `"https://wharf.stage.atlas.dgc.local"`
+
+### `api.http.oidc.scope`
+
+> List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
+
+*Type:* `string`\
+*Default:* `"openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"`
+
+### `api.http.oidc.silentRenew`
+
+> Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
+
+*Type:* `bool`\
+*Default:* `true`
+
+### `api.http.oidc.useRefreshToken`
+
+> When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
+
+*Type:* `bool`\
+*Default:* `true`
+
 ### `api.image`
 
 > Docker image that runs the frontend/web
@@ -266,21 +337,21 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `imagePullSecrets`
 
->
+> 
 
 *Type:* `list`\
 *Default:* `[]`
 
 ### `ingress.annotations`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingress.apiVersion`
 
->
+> 
 
 *Type:* `string`\
 *Default:* `"networking.k8s.io/v1beta1"`
@@ -301,14 +372,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingress.tls`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingressRoute.apiVersion`
 
->
+> 
 
 *Type:* `string`\
 *Default:* `"traefik.containo.us/v1alpha1"`
@@ -322,7 +393,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[0].annotations`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
@@ -350,14 +421,14 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[0].tls`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
 
 ### `ingressRoute.entries[1].annotations`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
@@ -371,7 +442,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[1].middlewares`
 
->
+> 
 
 *Type:* `list`\
 *Default:* `[]`
@@ -385,7 +456,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `ingressRoute.entries[1].tls.secretName`
 
->
+> 
 
 *Type:* `string`\
 *Default:* `"wharf-example-tls"`
@@ -511,7 +582,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `providers.example.imagePullSecrets`
 
->
+> 
 
 *Type:* `list`\
 *Default:* `[]`
@@ -546,7 +617,7 @@ helm install my-release iver-wharf/wharf-helm
 
 ### `providers.example.podAnnotations`
 
->
+> 
 
 *Type:* `object`\
 *Default:* `{}`
@@ -816,6 +887,7 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `list`\
 *Default:* `[{"emptyDir":{},"name":"cache"},{"emptyDir":{},"name":"run"}]`
+
 
 ## Smart environment fields
 

--- a/charts/wharf-helm/ci/test-values.yaml
+++ b/charts/wharf-helm/ci/test-values.yaml
@@ -22,17 +22,6 @@ web:
       cpu: 100m
       memory: 128Mi
 
-  http:
-    oidc:
-      authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
-      clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
-      scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
-      logLevel: "debug"
-      useRefreshToken: true
-      silentRenew: true
-      ignoreNonceAfterRefresh: true
-      maxIdTokenIatOffsetAllowedInSeconds: 600
-
 api:
   imagePullPolicy: IfNotPresent
 

--- a/charts/wharf-helm/ci/test-values.yaml
+++ b/charts/wharf-helm/ci/test-values.yaml
@@ -22,6 +22,17 @@ web:
       cpu: 100m
       memory: 128Mi
 
+  http:
+    oidc:
+      authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
+      clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
+      scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
+      logLevel: "debug"
+      useRefreshToken: true
+      silentRenew: true
+      ignoreNonceAfterRefresh: true
+      maxIdTokenIatOffsetAllowedInSeconds: 600
+
 api:
   imagePullPolicy: IfNotPresent
 

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -112,11 +112,11 @@ data:
           "logLevel": "{{ .logLevel }}",
           "useRefreshToken": {{ .useRefreshToken }},
           "silentRenew": {{ .silentRenew }},
-          "responseType": "{{ .responseType }}",
+          "responseType": "id_token token",
           "ignoreNonceAfterRefresh": {{ .ignoreNonceAfterRefresh }},
           "maxIdTokenIatOffsetAllowedInSeconds": {{ .maxIdTokenIatOffsetAllowedInSeconds }},
-          "issValidationOff": {{ .issValidationOff }},
-          "autoUserInfo": {{ .autoUserInfo }}
+          "issValidationOff": false,
+          "autoUserInfo": false
       },
       {{- end }}
       "BackendUrls": {

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -125,5 +125,4 @@ data:
           "GithubImport" : "/import",
           "AzureDevopsImport" : "/import"
       }
-
     }

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -102,7 +102,7 @@ data:
       },
       "UpdateLatency": 20000,
       "UpdateFrequency": 30000,
-      {{- with $.Values.web.http.oidc }}
+      {{- with .Values.web.oidc }}
       "oidcConfig": {
           "authority": "{{ .authority }}",
           "redirectUrl": "{{ (printf "https://%s" $.Values.global.url) }}",

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -103,7 +103,7 @@ data:
       "UpdateLatency": 20000,
       "UpdateFrequency": 30000,
       {{- with $.Values.web.http.oidc }}
-      {
+      "oidcConfig": {
           "authority": "{{ .authority }}",
           "redirectUrl": "{{ .redirectUrl }}",
           "postLogoutRedirectUri": "{{ .postLogoutRedirectUri }}",

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -105,8 +105,8 @@ data:
       {{- with $.Values.web.http.oidc }}
       "oidcConfig": {
           "authority": "{{ .authority }}",
-          "redirectUrl": "{{ .redirectUrl }}",
-          "postLogoutRedirectUri": "{{ .postLogoutRedirectUri }}",
+          "redirectUrl": "{{ .redirectUrl | default (printf "https://%s" $.Values.global.url) }}",
+          "postLogoutRedirectUri": "{{ .redirectUrl | default (printf "https://%s" $.Values.global.url) }}",
           "clientId": "{{ .clientId }}",
           "scope": "{{ .scope }}",
           "logLevel": "{{ .logLevel }}",

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -102,10 +102,28 @@ data:
       },
       "UpdateLatency": 20000,
       "UpdateFrequency": 30000,
+      {{- with $.Values.web.http.oidc }}
+      {
+          "authority": "{{ .authority }}",
+          "redirectUrl": "{{ .redirectUrl }}",
+          "postLogoutRedirectUri": "{{ .postLogoutRedirectUri }}",
+          "clientId": "{{ .clientId }}",
+          "scope": "{{ .scope }}",
+          "logLevel": "{{ .logLevel }}",
+          "useRefreshToken": {{ .useRefreshToken }},
+          "silentRenew": {{ .silentRenew }},
+          "responseType": "{{ .responseType }}",
+          "ignoreNonceAfterRefresh": {{ .ignoreNonceAfterRefresh }},
+          "maxIdTokenIatOffsetAllowedInSeconds": {{ .maxIdTokenIatOffsetAllowedInSeconds }},
+          "issValidationOff": {{ .issValidationOff }},
+          "autoUserInfo": {{ .autoUserInfo }}
+      },
+      {{- end }}
       "BackendUrls": {
           "Api": "/api",
           "GitlabImport" : "/import",
           "GithubImport" : "/import",
           "AzureDevopsImport" : "/import"
       }
+
     }

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -105,8 +105,8 @@ data:
       {{- with $.Values.web.http.oidc }}
       "oidcConfig": {
           "authority": "{{ .authority }}",
-          "redirectUrl": "{{ .redirectUrl | default (printf "https://%s" $.Values.global.url) }}",
-          "postLogoutRedirectUri": "{{ .redirectUrl | default (printf "https://%s" $.Values.global.url) }}",
+          "redirectUrl": "{{ (printf "https://%s" $.Values.global.url) }}",
+          "postLogoutRedirectUri": "{{ (printf "https://%s" $.Values.global.url) }}",
           "clientId": "{{ .clientId }}",
           "scope": "{{ .scope }}",
           "logLevel": "{{ .logLevel }}",

--- a/charts/wharf-helm/templates/web.yaml
+++ b/charts/wharf-helm/templates/web.yaml
@@ -95,34 +95,24 @@ metadata:
 data:
   config.json: |
     {
-      "Environment":
-      {
-          "Name": {{ .Values.global.instanceId | quote }},
-          "IsProduction": {{ .Values.global.isProduction }}
+      "Environment": {
+        "Name": {{ .Values.global.instanceId | quote }},
+        "IsProduction": {{ .Values.global.isProduction }}
       },
       "UpdateLatency": 20000,
       "UpdateFrequency": 30000,
+      {{- if .Values.web.oidcEnabled }}
       {{- with .Values.web.oidc }}
-      "oidcConfig": {
-          "authority": "{{ .authority }}",
-          "redirectUrl": "{{ (printf "https://%s" $.Values.global.url) }}",
-          "postLogoutRedirectUri": "{{ (printf "https://%s" $.Values.global.url) }}",
-          "clientId": "{{ .clientId }}",
-          "scope": "{{ .scope }}",
-          "logLevel": "{{ .logLevel }}",
-          "useRefreshToken": {{ .useRefreshToken }},
-          "silentRenew": {{ .silentRenew }},
-          "responseType": "id_token token",
-          "ignoreNonceAfterRefresh": {{ .ignoreNonceAfterRefresh }},
-          "maxIdTokenIatOffsetAllowedInSeconds": {{ .maxIdTokenIatOffsetAllowedInSeconds }},
-          "issValidationOff": false,
-          "autoUserInfo": false
-      },
+      {{- $conf := . }}
+      {{- $conf := get . "redirectUrl" | default ((printf "https://%s" $.Values.global.url)) | set $conf "redirectUrl" }}
+      {{- $conf := get . "postLogoutRedirectUri" | default ((printf "https://%s" $.Values.global.url)) | set $conf "postLogoutRedirectUri" }}
+      "oidcConfig": {{ $conf | toPrettyJson | indent 6 | trim }},
+      {{- end }}
       {{- end }}
       "BackendUrls": {
-          "Api": "/api",
-          "GitlabImport" : "/import",
-          "GithubImport" : "/import",
-          "AzureDevopsImport" : "/import"
+        "Api": "/api",
+        "GitlabImport" : "/import",
+        "GithubImport" : "/import",
+        "AzureDevopsImport" : "/import"
       }
     }

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -101,32 +101,35 @@ web:
   # listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   containerPort: 8080
 
-  # -- Settings for the OpenId Connect authentication login.
+  # -- If this is `false` or unset then no OIDC configs will be applied.
+  oidcEnabled: false
+
+  # -- Settings for the OpenId Connect authentication login. These are the
+  # config values for the angular-auth-oidc-client NPM package that wharf-web
+  # uses.
+  #
+  # The `web.oidc.redirectUrl` and `web.oidc.postLogoutRedirectUri` defaults to
+  # the `global.url` Helm value prefixed with `https://`.
+  #
+  # See documentation on configs here: https://nice-hill-002425310.azurestaticapps.net/docs/documentation/configuration#config-values
+  # See source code for configs here: https://github.com/damienbod/angular-auth-oidc-client/blob/release_13_1_0/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+  #
+  # Note: These configs are ignored unless `web.oidcEnabled` is set to `true`.
   oidc:
+    redirectUrl: # defaults to `https://` added to the `global.url` value
+    postLogoutRedirectUri: # defaults to `https://` added to the `global.url` value
 
-    # -- The url to the Security Token Service (STS). The authority issues tokens. This field is required.
     authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
-
-    # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
     clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
-
-    # -- List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
+    responseType: id_token token
     scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
-
-    # -- 0, 1, 2 can be used to set the log level displayed in the console.
-    logLevel: "debug"
-
-    # -- When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
+    logLevel: 2
     useRefreshToken: true
-
-    # -- Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
     silentRenew: true
-
-    # -- A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
     ignoreNonceAfterRefresh: true
-
-    # -- Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
     maxIdTokenIatOffsetAllowedInSeconds: 600
+    issValidationOff: false
+    autoUserInfo: false
 
 api:
   # -- Number of deployment replicas.

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -201,12 +201,6 @@ api:
       # -- The url to the Security Token Service (STS). The authority issues tokens. This field is required.
       authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
 
-      # -- The redirect URL defined on the Security Token Service.
-      redirectUrl: ""
-
-      # -- URL to redirect to after a server logout if using the end session API.
-      postLogoutRedirectUri: ""
-
       # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
       clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -101,6 +101,33 @@ web:
   # listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   containerPort: 8080
 
+  # -- Settings for the OpenId Connect authentication login.
+  oidc:
+
+    # -- The url to the Security Token Service (STS). The authority issues tokens. This field is required.
+    authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
+
+    # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
+    clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
+
+    # -- List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
+    scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
+
+    # -- 0, 1, 2 can be used to set the log level displayed in the console.
+    logLevel: "debug"
+
+    # -- When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
+    useRefreshToken: true
+
+    # -- Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
+    silentRenew: true
+
+    # -- A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
+    ignoreNonceAfterRefresh: true
+
+    # -- Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
+    maxIdTokenIatOffsetAllowedInSeconds: 600
+
 api:
   # -- Number of deployment replicas.
   replicaCount: 1
@@ -194,33 +221,6 @@ api:
     # Sets `WHARF_HTTP_BINDADDRESS` environment variable.
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     bindAddress: "0.0.0.0:8080"
-
-    # --
-    oidc:
-
-      # -- The url to the Security Token Service (STS). The authority issues tokens. This field is required.
-      authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
-
-      # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
-      clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
-
-      # -- List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
-      scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
-
-      # -- 0, 1, 2 can be used to set the log level displayed in the console.
-      logLevel: "debug"
-
-      # -- When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
-      useRefreshToken: true
-
-      # -- Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
-      silentRenew: true
-
-      # -- A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
-      ignoreNonceAfterRefresh: true
-
-      # -- Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
-      maxIdTokenIatOffsetAllowedInSeconds: 600
 
   # Settings for Wharf API's database connection
   db:

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -195,6 +195,37 @@ api:
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     bindAddress: "0.0.0.0:8080"
 
+    # --
+    oidc:
+
+      # --
+      authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
+      # --
+      redirectUrl: "https://wharf.stage.atlas.dgc.local"
+      # --
+      postLogoutRedirectUri: "https://wharf.stage.atlas.dgc.local"
+      # --
+      clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
+      # --
+      scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
+      # --
+      logLevel: "debug"
+      # --
+      useRefreshToken: true
+      # --
+      silentRenew: "id_token token"
+      # --
+      responseType: true
+      # --
+      ignoreNonceAfterRefresh: true
+      # --
+      maxIdTokenIatOffsetAllowedInSeconds: 600
+      # --
+      issValidationOff: false
+      # --
+      autoUserInfo: false
+      # --
+
   # Settings for Wharf API's database connection
   db:
     # -- Currently only `"postgres"` is a valid value here. Set to `null` or

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -202,10 +202,10 @@ api:
       authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
 
       # -- The redirect URL defined on the Security Token Service.
-      redirectUrl: "https://wharf.stage.atlas.dgc.local"
+      redirectUrl: ""
 
       # -- URL to redirect to after a server logout if using the end session API.
-      postLogoutRedirectUri: "https://wharf.stage.atlas.dgc.local"
+      postLogoutRedirectUri: ""
 
       # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
       clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -198,33 +198,35 @@ api:
     # --
     oidc:
 
-      # --
+      # -- The url to the Security Token Service (STS). The authority issues tokens. This field is required.
       authority: "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/v2.0/.well-known/openid-configuration"
-      # --
+
+      # -- The redirect URL defined on the Security Token Service.
       redirectUrl: "https://wharf.stage.atlas.dgc.local"
-      # --
+
+      # -- URL to redirect to after a server logout if using the end session API.
       postLogoutRedirectUri: "https://wharf.stage.atlas.dgc.local"
-      # --
+
+      # -- The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
       clientId: "01fcb3dc-7a2b-4b1c-a7d6-d7033089c779"
-      # --
+
+      # -- List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use. The openid scope is required. The offline_access scope can be requested when using refresh tokens but this is optional and some Security Token Service do not support this or recommend not requesting this even when using refresh tokens in the browser.
       scope: "openid profile email offline_access api://wharf-internal/read api://wharf-internal/admin api://wharf-internal/deploy"
-      # --
+
+      # -- 0, 1, 2 can be used to set the log level displayed in the console.
       logLevel: "debug"
-      # --
+
+      # -- When set to true, refresh tokens are used to renew the user session. When set to false, standard silent renew is used. Default value is false.
       useRefreshToken: true
-      # --
-      silentRenew: "id_token token"
-      # --
-      responseType: true
-      # --
+
+      # -- Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
+      silentRenew: true
+
+      # -- A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
       ignoreNonceAfterRefresh: true
-      # --
+
+      # -- Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
       maxIdTokenIatOffsetAllowedInSeconds: 600
-      # --
-      issValidationOff: false
-      # --
-      autoUserInfo: false
-      # --
 
   # Settings for Wharf API's database connection
   db:


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-helm/Chart.yml`

## Summary

This adds a config set for OIDC in web under the keys `.web.oidc.*`.

Added an entry for versionbumping chart.yml to the feature template.

## Motivation

The helm chart currently overrides the wharf-web repo's config. As the module is always loaded in we need a valid config to not crash the app. This default config will be sufficient not to crash the app but will likely need to be configured in the case that it is to be used.

The template update should make it easier to remember the two locations for the version bumping, and might save someone a first failed github action run.