### PR TITLE
Updated wharf-provider-github to v3.0.0

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.1.2
+
+- Changed image version of `github` from v2.0.0 to v3.0.0. (#33)
+
 ## v3.1.1
 
 - Changed image version of `api` from v5.0.0 to v5.1.2. (#32)

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.1.1
+version: 3.1.2
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square)
+![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -34,7 +34,7 @@ helm install my-release iver-wharf/wharf-helm
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.1.2](https://img.shields.io/badge/Version-v5.1.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.1.2"`
 | [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.1](https://img.shields.io/badge/Version-v1.5.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.1"`
-| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
+| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
 
@@ -633,7 +633,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `github` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-github:v2.0.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
 
 ### `providers.github.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -467,7 +467,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `github` provider
-    image: quay.io/iver-wharf/wharf-provider-github:v2.0.0
+    image: quay.io/iver-wharf/wharf-provider-github:v3.0.0
     # -- Default image pull policy used in the `github` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `github` provider


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-helm/CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
  (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-helm/Chart.yml`

## Summary

- Updated wharf-provider-github from v2.0.0 to v3.0.0

## Motivation

New version of the GitHub provider: https://github.com/iver-wharf/wharf-provider-github/releases/tag/v3.0.0

I did not do a major version bump, even if the GitHub provider had a major version bump, because the breaking change in the GitHub provider is the dropped support of wharf-api v4.x.x and below, and wharf-helm already has done a major version bump for the same reason.
