### PR TITLE
wharf-cmd: More configurability

### DIFF
--- a/charts/wharf-cmd/Chart.yaml
+++ b/charts/wharf-cmd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-cmd
 description: Deploy wharf-cmd, Wharf's execution engine, to Kubernetes.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.8.0"
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd
 maintainers:

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -25,6 +25,37 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-cmd](https://github.com/iver-wharf/wharf-cmd) | [![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-cmd) |`"quay.io/iver-wharf/wharf-cmd:latest"`
 
+## Configs disclaimer
+
+The chart allows you to set YAML configs for the different components.
+
+Please note that wharf-cmd does not support hot-reloading configs, so if you
+do a Helm upgrade with only configs changes, then Kubernetes only updates
+the ConfigMaps and will not restart the services for you.
+
+To restart the services manually, you can delete the pods, and let the
+Deployment recreate them, like so:
+
+```console
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd
+pod "wharf-cmd-stage-aggregator-857b7d4949-4dgnk" deleted
+pod "wharf-cmd-stage-provisioner-8b5b5f85c-b4fqj" deleted
+pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
+```
+
+Or delete only one of the components:
+
+```console
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=aggregator
+pod "wharf-cmd-stage-aggregator-857b7d4949-4dgnk" deleted
+
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=provisioner
+pod "wharf-cmd-stage-provisioner-8b5b5f85c-b4fqj" deleted
+
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=watchdog
+pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -30,6 +30,7 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | aggregator.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| aggregator.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | aggregator.enabled | bool | `true` | Enable the wharf-cmd-aggregator component. |
 | aggregator.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | aggregator.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
@@ -37,12 +38,14 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | aggregator.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | aggregator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Selects which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | aggregator.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| common.config | object | `{}` | Default configuration for all components. This is later merged with each per-component configs, where their config values take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | common.image | string | `"quay.io/iver-wharf/wharf-cmd:latest"` | Default Docker image for all components. The same image can be used for all wharf-cmd components as it uses the same binary to perform the different tasks. |
 | common.loglevel | string | `"debug"` | Default logging level for all components. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | fullnameOverride | string | `""` | String to fully override the pod and service names. If set, deployments, services, ingresses, *etc*, will use this name, and `nameOverride` will be ignored. |
 | global.instanceId | string | `"dev"` | Used by Wharf to differentiate between installations in the same namespace. |
 | nameOverride | string | `""` | String to partially override the pod and service names. Will maintain the release name. |
 | provisioner.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| provisioner.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | provisioner.containerPort | int | `5009` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
 | provisioner.enabled | bool | `true` | Enable the wharf-cmd-provisioner component. |
 | provisioner.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
@@ -54,6 +57,7 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | provisioner.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | provisioner.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | watchdog.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| watchdog.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | watchdog.enabled | bool | `false` | Enable the wharf-cmd-watchdog component. |
 | watchdog.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | watchdog.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd>
@@ -31,6 +31,7 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 |-----|------|---------|-------------|
 | aggregator.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | aggregator.enabled | bool | `true` | Enable the wharf-cmd-aggregator component. |
+| aggregator.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | aggregator.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | aggregator.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | aggregator.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
@@ -39,10 +40,12 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | common.image | string | `"quay.io/iver-wharf/wharf-cmd:latest"` | Default Docker image for all components. The same image can be used for all wharf-cmd components as it uses the same binary to perform the different tasks. |
 | common.loglevel | string | `"debug"` | Default logging level for all components. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | fullnameOverride | string | `""` | String to fully override the pod and service names. If set, deployments, services, ingresses, *etc*, will use this name, and `nameOverride` will be ignored. |
+| global.instanceId | string | `"dev"` | Used by Wharf to differentiate between installations in the same namespace. |
 | nameOverride | string | `""` | String to partially override the pod and service names. Will maintain the release name. |
 | provisioner.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | provisioner.containerPort | int | `5009` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
 | provisioner.enabled | bool | `true` | Enable the wharf-cmd-provisioner component. |
+| provisioner.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | provisioner.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | provisioner.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | provisioner.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
@@ -52,6 +55,7 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | provisioner.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | watchdog.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | watchdog.enabled | bool | `false` | Enable the wharf-cmd-watchdog component. |
+| watchdog.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | watchdog.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | watchdog.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | watchdog.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |

--- a/charts/wharf-cmd/README.md.gotmpl
+++ b/charts/wharf-cmd/README.md.gotmpl
@@ -48,6 +48,37 @@ helm install wharf-cmd iver-wharf/wharf-cmd
 | ----------------- | --------------- | -----
 | {{ template "wharf-helm.imageColumns" $defaultValues.common_image }}
 
+## Configs disclaimer
+
+The chart allows you to set YAML configs for the different components.
+
+Please note that wharf-cmd does not support hot-reloading configs, so if you
+do a Helm upgrade with only configs changes, then Kubernetes only updates
+the ConfigMaps and will not restart the services for you.
+
+To restart the services manually, you can delete the pods, and let the
+Deployment recreate them, like so:
+
+```console
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd
+pod "wharf-cmd-stage-aggregator-857b7d4949-4dgnk" deleted
+pod "wharf-cmd-stage-provisioner-8b5b5f85c-b4fqj" deleted
+pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
+```
+
+Or delete only one of the components:
+
+```console
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=aggregator
+pod "wharf-cmd-stage-aggregator-857b7d4949-4dgnk" deleted
+
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=provisioner
+pod "wharf-cmd-stage-provisioner-8b5b5f85c-b4fqj" deleted
+
+$ kubectl delete pod -l app.kubernetes.io/name=wharf-cmd,component=watchdog
+pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
+```
+
 {{ template "chart.valuesSection" . }}
 
 ## Changes

--- a/charts/wharf-cmd/templates/aggregator.yaml
+++ b/charts/wharf-cmd/templates/aggregator.yaml
@@ -26,10 +26,6 @@ spec:
           args: 
             - --loglevel
             - {{ .Values.aggregator.loglevel | default .Values.common.loglevel | quote }}
-            {{- with .Values.global.instanceId }}
-            - --instance
-            - {{- . | quote }}
-            {{- end }}
             - aggregator
             - serve
             {{- with .Values.aggregator.extraArgs }}
@@ -38,6 +34,10 @@ spec:
           {{- with .Values.aggregator.extraEnvs }}
           env: {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+          - mountPath: /etc/iver-wharf/wharf-cmd
+            name: config
+            readOnly: true
       {{- with .Values.aggregator.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -47,4 +47,20 @@ spec:
       {{- with .Values.aggregator.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "wharf-cmd.fullname" . }}-aggregator-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wharf-cmd.fullname" . }}-aggregator-config
+  labels:
+    component: aggregator
+    {{- include "wharf-cmd.labels" . | nindent 4 }}
+data:
+  wharf-cmd-config.yml: |
+    instanceId: {{ .Values.global.instanceId | quote }}
+    {{- deepCopy .Values.common.config | merge .Values.aggregator.config | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/wharf-cmd/templates/aggregator.yaml
+++ b/charts/wharf-cmd/templates/aggregator.yaml
@@ -23,9 +23,20 @@ spec:
         - name: aggregator
           image: {{ .Values.aggregator.image | default .Values.common.image | quote }}
           imagePullPolicy: Always
-          args: [ aggregator, serve, --loglevel, {{ .Values.aggregator.loglevel | default .Values.common.loglevel | quote }} ]
+          args: 
+            - --loglevel
+            - {{ .Values.aggregator.loglevel | default .Values.common.loglevel | quote }}
+            {{- with .Values.global.instanceId }}
+            - --instance
+            - {{- . | quote }}
+            {{- end }}
+            - aggregator
+            - serve
+            {{- with .Values.aggregator.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.aggregator.extraEnvs }}
-          env: {{- toYaml . | nindent 12}}
+          env: {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.aggregator.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -26,10 +26,6 @@ spec:
           args:
             - --loglevel
             - {{ .Values.provisioner.loglevel | default .Values.common.loglevel | quote }}
-            {{- with .Values.global.instanceId }}
-            - --instance
-            - {{- . | quote }}
-            {{- end }}
             - provisioner
             - serve
             {{- with .Values.provisioner.extraArgs }}
@@ -38,6 +34,10 @@ spec:
           {{- with .Values.provisioner.extraEnvs }}
           env: {{- toYaml . | nindent 12}}
           {{- end }}
+          volumeMounts:
+          - mountPath: /etc/iver-wharf/wharf-cmd
+            name: config
+            readOnly: true
           livenessProbe:
             httpGet:
               path: /
@@ -59,6 +59,22 @@ spec:
       {{- with .Values.provisioner.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "wharf-cmd.fullname" . }}-provisioner-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wharf-cmd.fullname" . }}-provisioner-config
+  labels:
+    component: provisioner
+    {{- include "wharf-cmd.labels" . | nindent 4 }}
+data:
+  wharf-cmd-config.yml: |
+    instanceId: {{ .Values.global.instanceId | quote }}
+    {{- deepCopy .Values.common.config | merge .Values.provisioner.config | toYaml | nindent 4 }}
 
 ---
 apiVersion: v1

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -23,7 +23,18 @@ spec:
         - name: provisioner
           image: {{ .Values.provisioner.image | default .Values.common.image | quote }}
           imagePullPolicy: Always
-          args: [ provisioner, serve, --loglevel, {{ .Values.provisioner.loglevel | default .Values.common.loglevel | quote }} ]
+          args:
+            - --loglevel
+            - {{ .Values.provisioner.loglevel | default .Values.common.loglevel | quote }}
+            {{- with .Values.global.instanceId }}
+            - --instance
+            - {{- . | quote }}
+            {{- end }}
+            - provisioner
+            - serve
+            {{- with .Values.provisioner.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.provisioner.extraEnvs }}
           env: {{- toYaml . | nindent 12}}
           {{- end }}

--- a/charts/wharf-cmd/templates/watchdog.yaml
+++ b/charts/wharf-cmd/templates/watchdog.yaml
@@ -26,10 +26,6 @@ spec:
           args: 
             - --loglevel
             - {{ .Values.watchdog.loglevel | default .Values.common.loglevel | quote }}
-            {{- with .Values.global.instanceId }}
-            - --instance
-            - {{- . | quote }}
-            {{- end }}
             - watchdog
             - serve
             {{- with .Values.watchdog.extraArgs }}
@@ -38,6 +34,10 @@ spec:
           {{- with .Values.watchdog.extraEnvs }}
           env: {{- toYaml . | nindent 12}}
           {{- end }}
+          volumeMounts:
+          - mountPath: /etc/iver-wharf/wharf-cmd
+            name: config
+            readOnly: true
       {{- with .Values.watchdog.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -47,4 +47,20 @@ spec:
       {{- with .Values.watchdog.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "wharf-cmd.fullname" . }}-watchdog-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wharf-cmd.fullname" . }}-watchdog-config
+  labels:
+    component: watchdog
+    {{- include "wharf-cmd.labels" . | nindent 4 }}
+data:
+  wharf-cmd-config.yml: |
+    instanceId: {{ .Values.global.instanceId | quote }}
+    {{- deepCopy .Values.common.config | merge .Values.watchdog.config | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/wharf-cmd/templates/watchdog.yaml
+++ b/charts/wharf-cmd/templates/watchdog.yaml
@@ -23,7 +23,18 @@ spec:
         - name: watchdog
           image: {{ .Values.watchdog.image | default .Values.common.image | quote }}
           imagePullPolicy: Always
-          args: [ watchdog, serve, --loglevel, {{ .Values.watchdog.loglevel | default .Values.common.loglevel | quote }} ]
+          args: 
+            - --loglevel
+            - {{ .Values.watchdog.loglevel | default .Values.common.loglevel | quote }}
+            {{- with .Values.global.instanceId }}
+            - --instance
+            - {{- . | quote }}
+            {{- end }}
+            - watchdog
+            - serve
+            {{- with .Values.watchdog.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.watchdog.extraEnvs }}
           env: {{- toYaml . | nindent 12}}
           {{- end }}

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -22,6 +22,11 @@ common:
   # binary to perform the different tasks.
   image: quay.io/iver-wharf/wharf-cmd:latest
 
+  # -- Default configuration for all components.
+  # This is later merged with each per-component configs, where their config
+  # values take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  config: {}
+
 aggregator:
   # -- Enable the wharf-cmd-aggregator component.
   enabled: true
@@ -51,6 +56,11 @@ aggregator:
 
   # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
+
+  # -- Configuration for wharf-cmd added only to the aggregator component.
+  # This is merged with `common.config`, where values here take precedence.
+  # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  config: {}
 
 provisioner:
   # -- Enable the wharf-cmd-provisioner component.
@@ -92,6 +102,11 @@ provisioner:
   # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
+  # -- Configuration for wharf-cmd added only to the aggregator component.
+  # This is merged with `common.config`, where values here take precedence.
+  # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  config: {}
+
 watchdog:
   # -- Enable the wharf-cmd-watchdog component.
   enabled: false
@@ -121,3 +136,8 @@ watchdog:
 
   # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
+
+  # -- Configuration for wharf-cmd added only to the aggregator component.
+  # This is merged with `common.config`, where values here take precedence.
+  # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  config: {}

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -7,6 +7,11 @@ nameOverride: ""
 # ignored.
 fullnameOverride: ""
 
+global:
+  # -- Used by Wharf to differentiate between installations in the same
+  # namespace.
+  instanceId: dev
+
 common:
   # -- Default logging level for all components.
   # Possible values: `debug`, `info`, `warn`, `error`, and `panic`.
@@ -43,6 +48,9 @@ aggregator:
   # -- Environment variables to add to the container.
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
+
+  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  extraArgs: []
 
 provisioner:
   # -- Enable the wharf-cmd-provisioner component.
@@ -81,6 +89,9 @@ provisioner:
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
 
+  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  extraArgs: []
+
 watchdog:
   # -- Enable the wharf-cmd-watchdog component.
   enabled: false
@@ -107,3 +118,6 @@ watchdog:
   # -- Environment variables to add to the container.
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
+
+  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  extraArgs: []


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Added --instance and extraArgs
- Added auto configs
- Added configs disclaimer

## Motivation

What bug or problem does this solve?
