### PR TITLE
Upgrade web to v1.6.0

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,11 +13,16 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.1.3
+## v3.2.0
 
 - Changed image version of `web` from v1.5.1 to v1.6.0. (#38)
+
 - Changed image version of `azuredevops` from v2.0.1 to v3.0.0. (#38)
+
 - Changed image version of `gitlab` from v1.3.0 to v2.0.0. (#38)
+
+- Removed Ingress & IngressRoute `apiVersion`, relying on automatic values
+  instead. (#38)
 
 ## v3.1.2
 

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.1.3
+
+- Changed image version of `web` from v1.5.1 to v1.6.0. (#38)
+
 ## v3.1.2
 
 - Changed image version of `github` from v2.0.0 to v3.0.0. (#33)

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -16,6 +16,8 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 ## v3.1.3
 
 - Changed image version of `web` from v1.5.1 to v1.6.0. (#38)
+- Changed image version of `azuredevops` from v2.0.1 to v3.0.0. (#38)
+- Changed image version of `gitlab` from v1.3.0 to v2.0.0. (#38)
 
 ## v3.1.2
 

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.1.3
+version: 3.2.0
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.1.2
+version: 3.1.3
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -35,8 +35,8 @@ helm install my-release iver-wharf/wharf-helm
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.1.2](https://img.shields.io/badge/Version-v5.1.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.1.2"`
 | [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.0](https://img.shields.io/badge/Version-v1.6.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.0"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
-| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
-| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
+| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0"`
+| [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v3.0.0"`
 
 ## Values
 
@@ -416,7 +416,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `azuredevops` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-azuredevops:v3.0.0"`
 
 ### `providers.azuredevops.imagePullPolicy`
 
@@ -668,7 +668,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `gitlab` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0"`
 
 ### `providers.gitlab.imagePullPolicy`
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -278,13 +278,6 @@ helm install my-release iver-wharf/wharf-helm
 *Type:* `object`\
 *Default:* `{}`
 
-### `ingress.apiVersion`
-
->
-
-*Type:* `string`\
-*Default:* `"networking.k8s.io/v1beta1"`
-
 ### `ingress.enabled`
 
 > Enables deploying a preconfigured Kubernetes Ingress to route traffic to the different Wharf services, using `global.url` as host name.
@@ -305,13 +298,6 @@ helm install my-release iver-wharf/wharf-helm
 
 *Type:* `object`\
 *Default:* `{}`
-
-### `ingressRoute.apiVersion`
-
->
-
-*Type:* `string`\
-*Default:* `"traefik.containo.us/v1alpha1"`
 
 ### `ingressRoute.enabled`
 

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square)
+![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -33,7 +33,7 @@ helm install my-release iver-wharf/wharf-helm
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.1.2](https://img.shields.io/badge/Version-v5.1.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.1.2"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.5.1](https://img.shields.io/badge/Version-v1.5.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.5.1"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.0](https://img.shields.io/badge/Version-v1.6.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.0"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v1.3.0](https://img.shields.io/badge/Version-v1.3.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1"`
@@ -731,7 +731,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.5.1"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.6.0"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/templates/ingress.yaml
+++ b/charts/wharf-helm/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "wharf-helm.fullname" . -}}
 {{- $svcPortWeb := .Values.web.servicePort -}}
 {{- $svcPortApi := .Values.api.servicePort -}}
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -26,7 +26,7 @@ spec:
       http:
         paths:
           - path: /
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
@@ -39,7 +39,7 @@ spec:
               servicePort: {{ $svcPortWeb }}
 {{- end }}
           - path: /api
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:
@@ -60,7 +60,7 @@ spec:
           {{- $providerName := $provider.name | default $providerName }}
           {{- $providerUrlBase := $provider.urlBaseOverride | default (printf "/import/%s" $providerName) }}
           - path: {{ $providerUrlBase | quote }}
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:

--- a/charts/wharf-helm/templates/ingress.yaml
+++ b/charts/wharf-helm/templates/ingress.yaml
@@ -26,24 +26,28 @@ spec:
       http:
         paths:
           - path: /
-            backend:
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
               service:
                 name: {{ printf "%v-web" $fullName | quote }}
                 port:
                   number: {{ $svcPortWeb }}
 {{- else }}
+            backend:
               serviceName: {{ printf "%v-web" $fullName | quote }}
               servicePort: {{ $svcPortWeb }}
 {{- end }}
           - path: /api
-            backend:
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
               service:
                 name: {{ printf "%v-api" $fullName | quote }}
                 port:
                   number: {{ $svcPortApi }}
 {{- else }}
+            backend:
               serviceName: {{ printf "%v-api" $fullName | quote }}
               servicePort: {{ $svcPortApi }}
 {{- end }}
@@ -56,13 +60,15 @@ spec:
           {{- $providerName := $provider.name | default $providerName }}
           {{- $providerUrlBase := $provider.urlBaseOverride | default (printf "/import/%s" $providerName) }}
           - path: {{ $providerUrlBase | quote }}
-            backend:
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            backend:
               service:
                 name: {{ printf "%s-%s" $fullName $providerName | quote }}
                 port:
                   number: {{ $provider.servicePort | default 80 }}
 {{- else }}
+            backend:
               serviceName: {{ printf "%s-%s" $fullName $providerName | quote }}
               servicePort: {{ $provider.servicePort | default 80 }}
 {{- end }}

--- a/charts/wharf-helm/templates/ingress.yaml
+++ b/charts/wharf-helm/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "wharf-helm.fullname" . -}}
 {{- $svcPortWeb := .Values.web.servicePort -}}
 {{- $svcPortApi := .Values.api.servicePort -}}
-apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" | quote }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName | quote }}

--- a/charts/wharf-helm/templates/ingress.yaml
+++ b/charts/wharf-helm/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "wharf-helm.fullname" . -}}
 {{- $svcPortWeb := .Values.web.servicePort -}}
 {{- $svcPortApi := .Values.api.servicePort -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -27,7 +27,7 @@ spec:
         paths:
           - path: /
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ printf "%v-web" $fullName | quote }}
                 port:
@@ -38,7 +38,7 @@ spec:
 {{- end }}
           - path: /api
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ printf "%v-api" $fullName | quote }}
                 port:
@@ -57,7 +57,7 @@ spec:
           {{- $providerUrlBase := $provider.urlBaseOverride | default (printf "/import/%s" $providerName) }}
           - path: {{ $providerUrlBase | quote }}
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ printf "%s-%s" $fullName $providerName | quote }}
                 port:

--- a/charts/wharf-helm/templates/ingress.yaml
+++ b/charts/wharf-helm/templates/ingress.yaml
@@ -27,12 +27,26 @@ spec:
         paths:
           - path: /
             backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ printf "%v-web" $fullName | quote }}
+                port:
+                  number: {{ $svcPortWeb }}
+{{- else }}
               serviceName: {{ printf "%v-web" $fullName | quote }}
               servicePort: {{ $svcPortWeb }}
+{{- end }}
           - path: /api
             backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ printf "%v-api" $fullName | quote }}
+                port:
+                  number: {{ $svcPortApi }}
+{{- else }}
               serviceName: {{ printf "%v-api" $fullName | quote }}
               servicePort: {{ $svcPortApi }}
+{{- end }}
           {{- with .Values.providers }}
           {{- range $providerName, $provider := . }}
           {{- if $provider.enabled }}
@@ -43,8 +57,15 @@ spec:
           {{- $providerUrlBase := $provider.urlBaseOverride | default (printf "/import/%s" $providerName) }}
           - path: {{ $providerUrlBase | quote }}
             backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ printf "%s-%s" $fullName $providerName | quote }}
+                port:
+                  number: {{ $provider.servicePort | default 80 }}
+{{- else }}
               serviceName: {{ printf "%s-%s" $fullName $providerName | quote }}
               servicePort: {{ $provider.servicePort | default 80 }}
+{{- end }}
           {{- end }}{{/* if provider.enabled */}}
           {{- end }}{{/* range of providers */}}
           {{- end }}{{/* with .Values.providers */}}

--- a/charts/wharf-helm/templates/ingressRoute.yaml
+++ b/charts/wharf-helm/templates/ingressRoute.yaml
@@ -2,12 +2,15 @@
 {{- $fullName := include "wharf-helm.fullname" . -}}
 {{- $svcPortWeb := .Values.web.servicePort -}}
 {{- $svcPortApi := .Values.api.servicePort -}}
-{{- $ingressRouteApiVersion := .Values.ingressRoute.apiVersion | default "traefik.containo.us/v1alpha1" -}}
 {{- $url := .Values.global.url }}
 {{- $labels := include "wharf-helm.labels" . }}
 
 {{- range $index, $entry := .Values.ingressRoute.entries -}}
-apiVersion: {{ $ingressRouteApiVersion | quote }}
+{{- if .Capabilities.APIVersions.Has "traefik.containo.us/v1" }}
+apiVersion: traefik.containo.us/v1
+{{- else }}
+apiVersion: traefik.containo.us/v1alpha1
+{{- end }}
 kind: IngressRoute
 metadata:
   name: {{ printf "%v-%v" $fullName $entry.name | quote }}

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -518,7 +518,6 @@ ingress:
   # -- Enables deploying a preconfigured Kubernetes Ingress to route traffic
   # to the different Wharf services, using `global.url` as host name.
   enabled: false
-  apiVersion: networking.k8s.io/v1beta1
   annotations: {}
   tls: {}
     # secretName: wharf-example-tls
@@ -536,7 +535,6 @@ ingressRoute:
   # -- Enables deploying a preconfigured Traefik IngressRoute to route traffic
   # to the different Wharf services, using `global.url` as host name.
   enabled: false
-  apiVersion: traefik.containo.us/v1alpha1
 
   entries:
     - # -- Only used in the IngressRoute object names

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -447,7 +447,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `gitlab` provider
-    image: quay.io/iver-wharf/wharf-provider-gitlab:v1.3.0
+    image: quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0
     # -- Default image pull policy used in the `gitlab` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the GitLab provider
@@ -487,7 +487,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `azuredevops` provider
-    image: quay.io/iver-wharf/wharf-provider-azuredevops:v2.0.1
+    image: quay.io/iver-wharf/wharf-provider-azuredevops:v3.0.0
     # -- Default image pull policy used in the `azuredevops` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `azuredevops` provider

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.5.1
+  image: quay.io/iver-wharf/wharf-web:v1.6.0
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Update web to newly released v1.6.0

## Motivation

Stay up to date
