### PR TITLE
Fixed capabilities check for IngressRoute

### DIFF
--- a/charts/wharf-helm/templates/ingressRoute.yaml
+++ b/charts/wharf-helm/templates/ingressRoute.yaml
@@ -6,7 +6,7 @@
 {{- $labels := include "wharf-helm.labels" . }}
 
 {{- range $index, $entry := .Values.ingressRoute.entries -}}
-{{- if .Capabilities.APIVersions.Has "traefik.containo.us/v1" }}
+{{- if $.Capabilities.APIVersions.Has "traefik.containo.us/v1" }}
 apiVersion: traefik.containo.us/v1
 {{- else }}
 apiVersion: traefik.containo.us/v1alpha1


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Fixed capabilities check for IngressRoute

## Motivation

Invalid chart
