### PR TITLE
wharf.iver.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Repository of Wharf's [Helm](https://helm.sh/) charts.
 To start using, add the Wharf Helm chart repository:
 
 ```sh
-helm repo add iver-wharf https://iver-wharf.github.io/wharf-helm
+helm repo add iver-wharf https://wharf.iver.com/wharf-helm
 ```
 
 ## Generating `charts/*/README.md`

--- a/charts/wharf-cmd/README.md.gotmpl
+++ b/charts/wharf-cmd/README.md.gotmpl
@@ -38,7 +38,7 @@ https://quay.io/repository/{{- regexReplaceAll "[\"`]*quay\\.io/(.*):.*" . "${1}
 To install the chart with the release name `my-release`:
 
 ```sh
-helm repo add iver-wharf https://iver-wharf.github.io/wharf-helm
+helm repo add iver-wharf https://wharf.iver.com/wharf-helm
 helm install wharf-cmd iver-wharf/wharf-cmd
 ```
 

--- a/charts/wharf-helm/README.md.gotmpl
+++ b/charts/wharf-helm/README.md.gotmpl
@@ -47,7 +47,7 @@ https://quay.io/repository/{{- regexReplaceAll "[\"`]*quay\\.io/(.*):.*" . "${1}
 To install the chart with the release name `my-release`:
 
 ```sh
-helm repo add iver-wharf https://iver-wharf.github.io/wharf-helm
+helm repo add iver-wharf https://wharf.iver.com/wharf-helm
 helm install my-release iver-wharf/wharf-helm
 ```
 


### PR DESCRIPTION
- \[ ] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[ ] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Changed docs to specify wharf.iver.com instead

## Motivation

We just got <https://wharf.iver.com>, which all of our GitHub Pages point to now, including this repo's
