### PR TITLE
Upgraded images

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,12 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.2.3
+
+- Changed image version of `web` from v1.6.0 to v1.6.1. (#43)
+- Changed image version of `api` from v5.1.2 to v5.2.0. (#43)
+- Changed image version of `gitlab` from v2.0.0 to v2.0.1. (#43)
+
 ## v3.2.2
 
 - Changed documentation of Helm repo from

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.2.2
+version: 3.2.3
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.2.2](https://img.shields.io/badge/Version-3.2.2-informational?style=flat-square)
+![Version: 3.2.3](https://img.shields.io/badge/Version-3.2.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -32,10 +32,10 @@ helm install my-release iver-wharf/wharf-helm
 
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
-| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.1.2](https://img.shields.io/badge/Version-v5.1.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.1.2"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.0](https://img.shields.io/badge/Version-v1.6.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.0"`
+| [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.2.0](https://img.shields.io/badge/Version-v5.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.2.0"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.1](https://img.shields.io/badge/Version-v1.6.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.1"`
 | [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
-| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v2.0.0](https://img.shields.io/badge/Version-v2.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0"`
+| [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.1"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v3.0.0"`
 
 ## Values
@@ -164,7 +164,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-api:v5.1.2"`
+*Default:* `"quay.io/iver-wharf/wharf-api:v5.2.0"`
 
 ### `api.imagePullPolicy`
 
@@ -654,7 +654,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `gitlab` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.1"`
 
 ### `providers.gitlab.imagePullPolicy`
 
@@ -717,7 +717,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.6.0"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.6.1"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.6.0
+  image: quay.io/iver-wharf/wharf-web:v1.6.1
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -136,7 +136,7 @@ api:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-api:v5.1.2
+  image: quay.io/iver-wharf/wharf-api:v5.2.0
   
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -447,7 +447,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `gitlab` provider
-    image: quay.io/iver-wharf/wharf-provider-gitlab:v2.0.0
+    image: quay.io/iver-wharf/wharf-provider-gitlab:v2.0.1
     # -- Default image pull policy used in the `gitlab` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the GitLab provider


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Changed image version of `web` from v1.6.0 to v1.6.1.
- Changed image version of `api` from v5.1.2 to v5.2.0.
- Changed image version of `gitlab` from v2.0.0 to v2.0.1.

## Motivation

Stay up to date. Lots of bug fixes.
