### PR TITLE
Add values for oidc validation config.

### DIFF
--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.2.5
+
+- Added settings for validation of OpenID Connect authentication tokens. (#45)
+
 ## v3.2.4
 
 - Added support for Ingress of apiVersion `extensions/v1beta1`,

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.2.4
+version: 3.2.5
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/templates/api.yaml
+++ b/charts/wharf-helm/templates/api.yaml
@@ -57,6 +57,14 @@ spec:
               {{- .basicAuth | include "wharf-helm.environmentValue" | nindent 14 }}
             - name: WHARF_HTTP_BINDADDRESS
               {{- .bindAddress | include "wharf-helm.environmentValue" | nindent 14 }}
+            - name: WHARF_HTTP_OIDC_ENABLE
+              {{- .enable }}
+            - name: WHARF_HTTP_OIDC_ISSUERURL
+              {{- .issuerURL }}
+            - name: WHARF_HTTP_OIDC_AUDIENCEURL
+              {{- .audienceURL }}
+            - name: WHARF_HTTP_OIDC_KEYSURL
+                {{- .keysURL }}
             {{- end }}{{/* with .Values.api.http */}}
 
             {{- if .Values.global.isProduction }}

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -225,6 +225,20 @@ api:
     # Supports ["Smart environment fields"](./README.md#smart-environment-fields)
     bindAddress: "0.0.0.0:8080"
 
+    # -- Settings for the validation of OpenId Connect authentication.
+    # This is a sample config for an azure id provider (app registration).
+    # One way to get this information about any token from an authentication flow is to use a flow dissection tool
+    # like https://oauth.tools
+    oidc:
+      # -- Unless enabled the backend will not preform any validation on any tokens.
+      enable: false
+      # -- In azure this is a way of differentiation between different app registrations.
+      issuerURL: 'https://sts.windows.net/841df554-ef9d-48b1-bc6e-44cf8543a8fc/'
+      # -- This name is set inside the app registration and can be used to differentiate between different token types.
+      audienceURL: 'api://wharf-internal'
+      # -- Keys are used to validate the token signature.
+      keysURL: 'https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/discovery/v2.0/keys'
+
   # Settings for Wharf API's database connection
   db:
     # -- Currently only `"postgres"` is a valid value here. Set to `null` or


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

Settings for OIDC token validation.

MIssing: 
- [ ] Some kind of generator run for README contents.
- [ ] More?

## Motivation

It enables config of oidc directly from the helm values file.
