### PR TITLE
wharf-helm: Upgraded images

### DIFF
--- a/charts/wharf-aino/CHANGELOG.md
+++ b/charts/wharf-aino/CHANGELOG.md
@@ -13,6 +13,15 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.1.2
+
+- Changed version of wharf-helm from 3.2.4 to 3.2.5. (#46)
+
+## v0.1.1
+
+- Changed version of wharf-helm from 3.2.3 to 3.2.4.
+- Changed version of wharf-cmd from 0.2.0 to 0.2.1.
+
 ## v0.1.0
 
 - Initial release

--- a/charts/wharf-aino/Chart.yaml
+++ b/charts/wharf-aino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-aino
 description: Wharf all-in-one, with wharf-helm, wharf-cmd, and Postgres
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: ""
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-aino
 maintainers:
@@ -16,7 +16,7 @@ annotations:
 
 dependencies:
   - name: wharf-helm
-    version: ">=3.2.4"
+    version: ">=3.2.5"
     repository: file://../wharf-helm
     condition: wharf-helm.enabled
 

--- a/charts/wharf-aino/README.md
+++ b/charts/wharf-aino/README.md
@@ -1,6 +1,6 @@
 # Wharf All-in-One chart
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-aino>

--- a/charts/wharf-helm/CHANGELOG.md
+++ b/charts/wharf-helm/CHANGELOG.md
@@ -13,6 +13,11 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.2.5
+
+- Changed image version of `web` from v1.6.1 to v1.6.2. (#46)
+- Changed image version of `github` from v3.0.0 to v3.0.1. (#46)
+
 ## v3.2.4
 
 - Added support for Ingress of apiVersion `extensions/v1beta1`,

--- a/charts/wharf-helm/Chart.yaml
+++ b/charts/wharf-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-helm
 description: Deploy Wharf to Kubernetes
 type: application
-version: 3.2.4
+version: 3.2.5
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm
 maintainers:
   - name: jilleJr

--- a/charts/wharf-helm/README.md
+++ b/charts/wharf-helm/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 3.2.4](https://img.shields.io/badge/Version-3.2.4-informational?style=flat-square)
+![Version: 3.2.5](https://img.shields.io/badge/Version-3.2.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-helm>
@@ -33,8 +33,8 @@ helm install my-release iver-wharf/wharf-helm
 | GitHub repository | Quay.io version | Image
 | ----------------- | --------------- | -----
 | [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) | [![Version: v5.2.0](https://img.shields.io/badge/Version-v5.2.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-api) |`"quay.io/iver-wharf/wharf-api:v5.2.0"`
-| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.1](https://img.shields.io/badge/Version-v1.6.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.1"`
-| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
+| [iver-wharf/wharf-web](https://github.com/iver-wharf/wharf-web) | [![Version: v1.6.2](https://img.shields.io/badge/Version-v1.6.2-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-web) |`"quay.io/iver-wharf/wharf-web:v1.6.2"`
+| [iver-wharf/wharf-provider-github](https://github.com/iver-wharf/wharf-provider-github) | [![Version: v3.0.1](https://img.shields.io/badge/Version-v3.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-github) |`"quay.io/iver-wharf/wharf-provider-github:v3.0.1"`
 | [iver-wharf/wharf-provider-gitlab](https://github.com/iver-wharf/wharf-provider-gitlab) | [![Version: v2.0.1](https://img.shields.io/badge/Version-v2.0.1-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-gitlab) |`"quay.io/iver-wharf/wharf-provider-gitlab:v2.0.1"`
 | [iver-wharf/wharf-provider-azuredevops](https://github.com/iver-wharf/wharf-provider-azuredevops) | [![Version: v3.0.0](https://img.shields.io/badge/Version-v3.0.0-informational?style=flat-square)](https://quay.io/repository/iver-wharf/wharf-provider-azuredevops) |`"quay.io/iver-wharf/wharf-provider-azuredevops:v3.0.0"`
 
@@ -619,7 +619,7 @@ helm install my-release iver-wharf/wharf-helm
 > Default image used in the `github` provider
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-provider-github:v3.0.0"`
+*Default:* `"quay.io/iver-wharf/wharf-provider-github:v3.0.1"`
 
 ### `providers.github.imagePullPolicy`
 
@@ -717,7 +717,7 @@ helm install my-release iver-wharf/wharf-helm
 > Docker image that runs the frontend/web
 
 *Type:* `string`\
-*Default:* `"quay.io/iver-wharf/wharf-web:v1.6.1"`
+*Default:* `"quay.io/iver-wharf/wharf-web:v1.6.2"`
 
 ### `web.imagePullPolicy`
 

--- a/charts/wharf-helm/values.yaml
+++ b/charts/wharf-helm/values.yaml
@@ -23,7 +23,7 @@ web:
   replicaCount: 1
 
   # -- Docker image that runs the frontend/web
-  image: quay.io/iver-wharf/wharf-web:v1.6.1
+  image: quay.io/iver-wharf/wharf-web:v1.6.2
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: ""
@@ -467,7 +467,7 @@ providers:
     # `providers.example.*` settings for a comparison.
     enabled: true
     # -- Default image used in the `github` provider
-    image: quay.io/iver-wharf/wharf-provider-github:v3.0.0
+    image: quay.io/iver-wharf/wharf-provider-github:v3.0.1
     # -- Default image pull policy used in the `github` provider
     imagePullPolicy: IfNotPresent
     # -- Default resources requested by the `github` provider


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Upgraded wharf-web to v1.6.2: https://github.com/iver-wharf/wharf-web/releases/tag/v1.6.2
- Upgraded wharf-provider-github to v3.0.1: https://github.com/iver-wharf/wharf-provider-github/releases/tag/v3.0.1

## Motivation

Stay up to date
