### PR TITLE
wharf-cmd: wharf-cmd-worker configs

### DIFF
--- a/charts/wharf-cmd/CHANGELOG.md
+++ b/charts/wharf-cmd/CHANGELOG.md
@@ -13,6 +13,21 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.3.0
+
+- Added values to set wharf-cmd-worker configs as well: (#48)
+
+  - `.Values.worker.config`
+  - `.Values.worker.extraArgs`
+  - `.Values.worker.extraEnvs`
+  - `.Values.worker.imagePullPolicy`
+  - `.Values.worker.imagePullSecrets`
+  - `.Values.worker.image`
+
+- Added values to set built-in variables: (#48)
+
+  - `.Values.worker.vars`
+
 ## v0.2.1
 
 - Changed documentation of Helm repo from

--- a/charts/wharf-cmd/Chart.yaml
+++ b/charts/wharf-cmd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-cmd
 description: Deploy wharf-cmd, Wharf's execution engine, to Kubernetes.
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "0.8.0"
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd
 maintainers:

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -65,10 +65,10 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | aggregator.enabled | bool | `true` | Enable the wharf-cmd-aggregator component. |
 | aggregator.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | aggregator.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
-| aggregator.image | string | common.image | Docker image of wharf-cmd-provisioner. |
+| aggregator.image | string | common.image | Docker image of wharf-cmd-aggregator. |
 | aggregator.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | aggregator.imagePullSecrets | list | common.imagePullSecrets | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
-| aggregator.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
+| aggregator.loglevel | string | common.loglevel | Logging level for wharf-cmd-aggregator. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | aggregator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Selects which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | aggregator.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | common.config | object | `{}` | Default configuration for all components. This is later merged with each per-component configs, where their config values take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
@@ -94,21 +94,22 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | provisioner.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | provisioner.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | watchdog.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| watchdog.config | object | common.config | Configuration for wharf-cmd added only to the provisioner component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| watchdog.config | object | common.config | Configuration for wharf-cmd added only to the watchdog component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | watchdog.enabled | bool | `false` | Enable the wharf-cmd-watchdog component. |
 | watchdog.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | watchdog.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
-| watchdog.image | string | common.image | Docker image of wharf-cmd-provisioner. |
+| watchdog.image | string | common.image | Docker image of wharf-cmd-watchdog. |
 | watchdog.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | watchdog.imagePullSecrets | list | common.imagePullSecrets | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
-| watchdog.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
+| watchdog.loglevel | string | common.loglevel | Logging level for wharf-cmd-watchdog. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | watchdog.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Selects which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | watchdog.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | worker.config | object | common.config | Configuration for wharf-cmd added only to the worker component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | worker.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | worker.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
-| worker.image | string | common.image | Docker image of wharf-cmd-provisioner. |
+| worker.image | string | common.image | Docker image of wharf-cmd-worker. |
 | worker.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| worker.imagePullSecrets | list | common.imagePullSecrets | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
 | worker.vars | object | `{"CHART_REPO":"https://harbor.local/chartrepo","REG_SECRET":"harbor-registry","REG_URL":"harbor.local"}` | Wharf built-in variables to use in a build. Each key-value pair will be available to all builds. |
 
 ## Changes

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd>

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -80,7 +80,7 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | global.instanceId | string | `"dev"` | Used by Wharf to differentiate between installations in the same namespace. |
 | nameOverride | string | `""` | String to partially override the pod and service names. Will maintain the release name. |
 | provisioner.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| provisioner.config | object | common.config | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| provisioner.config | object | common.config | Configuration for wharf-cmd added only to the provisioner component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | provisioner.containerPort | int | `5009` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
 | provisioner.enabled | bool | `true` | Enable the wharf-cmd-provisioner component. |
 | provisioner.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -110,7 +110,7 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | worker.image | string | common.image | Docker image of wharf-cmd-worker. |
 | worker.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | worker.imagePullSecrets | list | common.imagePullSecrets | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
-| worker.vars | object | `{"CHART_REPO":"https://harbor.local/chartrepo","REG_SECRET":"harbor-registry","REG_URL":"harbor.local"}` | Wharf built-in variables to use in a build. Each key-value pair will be available to all builds. |
+| worker.vars | object | `{}` | Wharf built-in variables to use in a build. Each key-value pair will be available to all builds. |
 
 ## Changes
 

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -61,9 +61,9 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | aggregator.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| aggregator.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| aggregator.config | object | common.config | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | aggregator.enabled | bool | `true` | Enable the wharf-cmd-aggregator component. |
-| aggregator.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
+| aggregator.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | aggregator.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | aggregator.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | aggregator.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
@@ -80,10 +80,10 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | global.instanceId | string | `"dev"` | Used by Wharf to differentiate between installations in the same namespace. |
 | nameOverride | string | `""` | String to partially override the pod and service names. Will maintain the release name. |
 | provisioner.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| provisioner.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| provisioner.config | object | common.config | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | provisioner.containerPort | int | `5009` | Container port. This needs to correlate to the port that the application listens on. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service) |
 | provisioner.enabled | bool | `true` | Enable the wharf-cmd-provisioner component. |
-| provisioner.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
+| provisioner.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | provisioner.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | provisioner.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | provisioner.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
@@ -94,9 +94,9 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | provisioner.serviceType | string | `"ClusterIP"` | Service type. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | provisioner.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | watchdog.affinity | object | `{}` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
-| watchdog.config | object | `{}` | Configuration for wharf-cmd added only to the aggregator component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| watchdog.config | object | common.config | Configuration for wharf-cmd added only to the provisioner component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
 | watchdog.enabled | bool | `false` | Enable the wharf-cmd-watchdog component. |
-| watchdog.extraArgs | list | `[]` | (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
+| watchdog.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
 | watchdog.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
 | watchdog.image | string | common.image | Docker image of wharf-cmd-provisioner. |
 | watchdog.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
@@ -104,6 +104,12 @@ pod "wharf-cmd-stage-watchdog-67d468df7f-278xn" deleted
 | watchdog.loglevel | string | common.loglevel | Logging level for wharf-cmd-provisioner. Possible values: `debug`, `info`, `warn`, `error`, and `panic`. |
 | watchdog.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Selects which node to run on, based on node labels. [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) |
 | watchdog.tolerations | list | `[]` | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| worker.config | object | common.config | Configuration for wharf-cmd added only to the worker component. This is merged with `common.config`, where values here take precedence. [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config) |
+| worker.extraArgs | list | `[]` | Arguments to add to the container. E.g `[ "--another-arg", "value" ]` |
+| worker.extraEnvs | list | `[]` | Environment variables to add to the container. [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/) |
+| worker.image | string | common.image | Docker image of wharf-cmd-provisioner. |
+| worker.imagePullPolicy | string | common.imagePullPolicy | [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
+| worker.vars | object | `{"CHART_REPO":"https://harbor.local/chartrepo","REG_SECRET":"harbor-registry","REG_URL":"harbor.local"}` | Wharf built-in variables to use in a build. Each key-value pair will be available to all builds. |
 
 ## Changes
 

--- a/charts/wharf-cmd/templates/aggregator.yaml
+++ b/charts/wharf-cmd/templates/aggregator.yaml
@@ -65,7 +65,8 @@ metadata:
     component: aggregator
     {{- include "wharf-cmd.labels" . | nindent 4 }}
 data:
+  {{- $config := deepCopy .Values.common.config | merge .Values.aggregator.config }}
+  {{- $config = dict "instanceId" .Values.global.instanceId | merge $config }}
   wharf-cmd-config.yml: |
-    {{- $config := deepCopy .Values.common.config | merge .Values.aggregator.config }}
-    {{- set $config "instanceId" .Values.global.instanceId | toYaml | nindent 4 }}
+    {{- $config | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -98,6 +98,9 @@ data:
   {{- with .Values.worker.extraArgs }}
     {{- $_ := . | set $workerConfig "extraArgs" }}
   {{- end }}
+  {{- with .Values.worker.imagePullSecrets | default .Values.common.imagePullSecrets }}
+    {{- $_ := . | set $workerConfig "imagePullSecrets" }}
+  {{- end }}
 
   {{- $config := deepCopy .Values.common.config | merge .Values.provisioner.config }}
   {{- $config = dict

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -77,10 +77,39 @@ metadata:
     component: provisioner
     {{- include "wharf-cmd.labels" . | nindent 4 }}
 data:
-  wharf-cmd-config.yml: |
-    {{- $config := deepCopy .Values.common.config | merge .Values.provisioner.config }}
-    {{- set $config "instanceId" .Values.global.instanceId | toYaml | nindent 4 }}
+  {{- $configContainer := dict }}
+  {{- with .Values.worker.image | default .Values.common.image }}
+    {{- $_ := regexReplaceAll "(.*):.*" . "${1}" | set $configContainer "image" }}
+    {{- $_ := regexReplaceAll ".*:(.*)" . "${1}" | default "latest" | set $configContainer "imageTag" }}
+  {{- end }}
+  {{- with .Values.worker.imagePullPolicy | default .Values.common.imagePullPolicy }}
+    {{- $_ := . | set $configContainer "imagePullPolicy" }}
+  {{- end }}
 
+  {{- $workerConfig := (dict
+    "configMapName" (printf "%s-worker" (include "wharf-cmd.fullname" .))
+  ) }}
+  {{- with $configContainer }}
+    {{- $_ := . | set $workerConfig "container" }}
+  {{- end }}
+  {{- with .Values.worker.extraEnvs }}
+    {{- $_ := . | set $workerConfig "extraEnvs" }}
+  {{- end }}
+  {{- with .Values.worker.extraArgs }}
+    {{- $_ := . | set $workerConfig "extraArgs" }}
+  {{- end }}
+
+  {{- $config := deepCopy .Values.common.config | merge .Values.provisioner.config }}
+  {{- $config = dict
+    "instanceId" .Values.global.instanceId
+    "provisioner" (dict
+      "k8s" (dict
+        "worker" $workerConfig
+      )
+    )
+    | merge $config }}
+  wharf-cmd-config.yml: |
+    {{- $config | toYaml | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -86,9 +86,7 @@ data:
     {{- $_ := . | set $configContainer "imagePullPolicy" }}
   {{- end }}
 
-  {{- $workerConfig := (dict
-    "configMapName" (printf "%s-worker" (include "wharf-cmd.fullname" .))
-  ) }}
+  {{- $workerConfig := (dict "configMapName" (printf "%s-worker" (include "wharf-cmd.fullname" .))) }}
   {{- with $configContainer }}
     {{- $_ := . | set $workerConfig "container" }}
   {{- end }}
@@ -102,15 +100,10 @@ data:
     {{- $_ := . | set $workerConfig "imagePullSecrets" }}
   {{- end }}
 
+  {{- $provisionerConfig := (dict "k8s" (dict "worker" $workerConfig)) }}
+
   {{- $config := deepCopy .Values.common.config | merge .Values.provisioner.config }}
-  {{- $config = dict
-    "instanceId" .Values.global.instanceId
-    "provisioner" (dict
-      "k8s" (dict
-        "worker" $workerConfig
-      )
-    )
-    | merge $config }}
+  {{- $config = dict "instanceId" .Values.global.instanceId "provisioner" $provisionerConfig | merge $config }}
   wharf-cmd-config.yml: |
     {{- $config | toYaml | nindent 4 }}
 ---

--- a/charts/wharf-cmd/templates/watchdog.yaml
+++ b/charts/wharf-cmd/templates/watchdog.yaml
@@ -65,7 +65,8 @@ metadata:
     component: watchdog
     {{- include "wharf-cmd.labels" . | nindent 4 }}
 data:
+  {{- $config := deepCopy .Values.common.config | merge .Values.watchdog.config }}
+  {{- $config = dict "instanceId" .Values.global.instanceId | merge $config }}
   wharf-cmd-config.yml: |
-    {{- $config := deepCopy .Values.common.config | merge .Values.watchdog.config }}
-    {{- set $config "instanceId" .Values.global.instanceId | toYaml | nindent 4 }}
+    {{- $config | toYaml | nindent 4 }}
 {{- end }}

--- a/charts/wharf-cmd/templates/worker.yaml
+++ b/charts/wharf-cmd/templates/worker.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wharf-cmd.fullname" . }}-worker-config
+  labels:
+    component: worker
+    {{- include "wharf-cmd.labels" . | nindent 4 }}
+data:
+  {{- $config := deepCopy .Values.common.config | merge .Values.worker.config }}
+  {{- $config = dict "instanceId" .Values.global.instanceId | merge $config }}
+  wharf-cmd-config.yml: |
+    {{- $config | toYaml | nindent 4 }}
+
+  {{- $wharfVars := .Values.worker.vars | default dict }}
+  wharf-vars.yml: |
+    vars: {{- $wharfVars | toYaml | nindent 6 }}

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -72,12 +72,13 @@ aggregator:
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
 
-  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
   # -- Configuration for wharf-cmd added only to the aggregator component.
   # This is merged with `common.config`, where values here take precedence.
   # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  # @default -- common.config
   config: {}
 
 provisioner:
@@ -126,12 +127,13 @@ provisioner:
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
 
-  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
   # -- Configuration for wharf-cmd added only to the aggregator component.
   # This is merged with `common.config`, where values here take precedence.
   # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  # @default -- common.config
   config: {}
 
 watchdog:
@@ -170,10 +172,41 @@ watchdog:
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []
 
-  # -- (string[]) Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
-  # -- Configuration for wharf-cmd added only to the aggregator component.
+  # -- Configuration for wharf-cmd added only to the provisioner component.
   # This is merged with `common.config`, where values here take precedence.
   # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  # @default -- common.config
   config: {}
+
+worker:
+  # -- Docker image of wharf-cmd-provisioner.
+  # @default -- common.image
+  image: ""
+
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+  # @default -- common.imagePullPolicy
+  imagePullPolicy: ""
+
+  #  - name: myDockerCredentialsSecret
+  # -- Environment variables to add to the container.
+  # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  extraEnvs: []
+
+  # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
+  extraArgs: []
+
+  # -- Configuration for wharf-cmd added only to the worker component.
+  # This is merged with `common.config`, where values here take precedence.
+  # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
+  # @default -- common.config
+  config: {}
+
+  # -- Wharf built-in variables to use in a build. Each key-value pair will be
+  # available to all builds.
+  vars:
+    CHART_REPO: https://harbor.local/chartrepo
+    REG_URL: harbor.local
+    REG_SECRET: harbor-registry

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -211,7 +211,7 @@ worker:
 
   # -- Wharf built-in variables to use in a build. Each key-value pair will be
   # available to all builds.
-  vars:
-    CHART_REPO: https://harbor.local/chartrepo
-    REG_URL: harbor.local
-    REG_SECRET: harbor-registry
+  vars: {}
+  #  CHART_REPO: https://harbor.local/chartrepo
+  #  REG_URL: harbor.local
+  #  REG_SECRET: harbor-registry

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -130,7 +130,7 @@ provisioner:
   # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
-  # -- Configuration for wharf-cmd added only to the aggregator component.
+  # -- Configuration for wharf-cmd added only to the provisioner component.
   # This is merged with `common.config`, where values here take precedence.
   # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
   # @default -- common.config

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -40,7 +40,7 @@ aggregator:
   # -- Enable the wharf-cmd-aggregator component.
   enabled: true
 
-  # -- Docker image of wharf-cmd-provisioner.
+  # -- Docker image of wharf-cmd-aggregator.
   # @default -- common.image
   image: ""
 
@@ -53,7 +53,7 @@ aggregator:
   imagePullSecrets: []
   #  - name: myDockerCredentialsSecret
 
-  # -- (string) Logging level for wharf-cmd-provisioner.
+  # -- (string) Logging level for wharf-cmd-aggregator.
   # Possible values: `debug`, `info`, `warn`, `error`, and `panic`.
   # @default -- common.loglevel
   loglevel: null
@@ -85,9 +85,9 @@ provisioner:
   # -- Enable the wharf-cmd-provisioner component.
   enabled: true
 
-  # -- (string) Docker image of wharf-cmd-provisioner.
+  # -- Docker image of wharf-cmd-provisioner.
   # @default -- common.image
-  image: null
+  image: ""
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   # @default -- common.imagePullPolicy
@@ -140,9 +140,9 @@ watchdog:
   # -- Enable the wharf-cmd-watchdog component.
   enabled: false
 
-  # -- (string) Docker image of wharf-cmd-provisioner.
+  # -- Docker image of wharf-cmd-watchdog.
   # @default -- common.image
-  image: null
+  image: ""
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   # @default -- common.imagePullPolicy
@@ -153,7 +153,7 @@ watchdog:
   imagePullSecrets: []
   #  - name: myDockerCredentialsSecret
 
-  # -- (string) Logging level for wharf-cmd-provisioner.
+  # -- (string) Logging level for wharf-cmd-watchdog.
   # Possible values: `debug`, `info`, `warn`, `error`, and `panic`.
   # @default -- common.loglevel
   loglevel: null
@@ -175,20 +175,25 @@ watchdog:
   # -- Arguments to add to the container. E.g `[ "--another-arg", "value" ]`
   extraArgs: []
 
-  # -- Configuration for wharf-cmd added only to the provisioner component.
+  # -- Configuration for wharf-cmd added only to the watchdog component.
   # This is merged with `common.config`, where values here take precedence.
   # [Read more (pkg.go.dev/github.com/iver-wharf/wharf-cmd)](https://pkg.go.dev/github.com/iver-wharf/wharf-cmd/pkg/config)
   # @default -- common.config
   config: {}
 
 worker:
-  # -- Docker image of wharf-cmd-provisioner.
+  # -- Docker image of wharf-cmd-worker.
   # @default -- common.image
   image: ""
 
   # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   # @default -- common.imagePullPolicy
   imagePullPolicy: ""
+
+  # -- [Read more (kubernetes.io/docs)](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  # @default -- common.imagePullSecrets
+  imagePullSecrets: []
+  #  - name: myDockerCredentialsSecret
 
   #  - name: myDockerCredentialsSecret
   # -- Environment variables to add to the container.

--- a/charts/wharf-cmd/values.yaml
+++ b/charts/wharf-cmd/values.yaml
@@ -195,7 +195,6 @@ worker:
   imagePullSecrets: []
   #  - name: myDockerCredentialsSecret
 
-  #  - name: myDockerCredentialsSecret
   # -- Environment variables to add to the container.
   # [Read more (kubernetes.io)](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   extraEnvs: []


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Support for worker configs
- Added imagePullSecrets
- Bumped version in Chart.yaml

## Motivation

Adds support for setting wharf-cmd-worker configs and built-in variables, as well as other settings
