### PR TITLE
wharf-cmd: Fix wharf-cmd-worker's configmap name

### DIFF
--- a/charts/wharf-aino/CHANGELOG.md
+++ b/charts/wharf-aino/CHANGELOG.md
@@ -13,6 +13,10 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.1.4
+
+- Changed version of wharf-cmd from 0.3.1 to 0.3.2. (#50)
+
 ## v0.1.3
 
 - Changed version of wharf-helm from 3.2.5 to 3.2.6. (#49)

--- a/charts/wharf-aino/Chart.yaml
+++ b/charts/wharf-aino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-aino
 description: Wharf all-in-one, with wharf-helm, wharf-cmd, and Postgres
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: ""
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-aino
 maintainers:
@@ -21,7 +21,7 @@ dependencies:
     condition: wharf-helm.enabled
 
   - name: wharf-cmd
-    version: ">=0.3.1"
+    version: ">=0.3.2"
     repository: file://../wharf-cmd
     condition: wharf-cmd.enabled
 

--- a/charts/wharf-aino/README.md
+++ b/charts/wharf-aino/README.md
@@ -1,6 +1,6 @@
 # Wharf All-in-One chart
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-aino>

--- a/charts/wharf-cmd/CHANGELOG.md
+++ b/charts/wharf-cmd/CHANGELOG.md
@@ -13,6 +13,11 @@ This chart tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.3.2
+
+- Fixed templating of wharf-cmd-provisioner's config of ConfigMap name to
+  mount into wharf-cmd-worker. (#50)
+
 ## v0.3.1
 
 - Changed version of wharf-cmd image from latest to v0.8.0. (#49)

--- a/charts/wharf-cmd/Chart.yaml
+++ b/charts/wharf-cmd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wharf-cmd
 description: Deploy wharf-cmd, Wharf's execution engine, to Kubernetes.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.8.0"
 home: https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd
 maintainers:

--- a/charts/wharf-cmd/README.md
+++ b/charts/wharf-cmd/README.md
@@ -1,6 +1,6 @@
 # Wharf Helm chart
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://github.com/iver-wharf/wharf-helm/blob/master/charts/wharf-cmd>

--- a/charts/wharf-cmd/templates/provisioner.yaml
+++ b/charts/wharf-cmd/templates/provisioner.yaml
@@ -86,7 +86,7 @@ data:
     {{- $_ := . | set $configContainer "imagePullPolicy" }}
   {{- end }}
 
-  {{- $workerConfig := (dict "configMapName" (printf "%s-worker" (include "wharf-cmd.fullname" .))) }}
+  {{- $workerConfig := (dict "configMapName" (printf "%s-worker-config" (include "wharf-cmd.fullname" .))) }}
   {{- with $configContainer }}
     {{- $_ := . | set $workerConfig "container" }}
   {{- end }}


### PR DESCRIPTION
- \[x] I've added a new note in the `charts/wharf-*/CHANGELOG.md` file, according to docs: https://iver-wharf.github.io/#/development/changelogs/writing-changelogs (but without version dates nor WIP versions)
- \[x] I've version bumped `charts/wharf-*/Chart.yml`

## Summary

- Fixed templating of the wharf-cmd-provisioner's configmap name to mount into wharf-cmd-worker

## Motivation

Bug
