### PR TITLE
Fixed outdated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `README.md` files in each chart is generated using
    If you have Go installed, you may run:
 
    ```sh
-   go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.5.0
+   go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.9.1
    ```
 
 2. Run `helm-docs`, preferrably before you create your pull requests:


### PR DESCRIPTION
## Summary

- Changed instruction for installing helm-docs to use version 1.9.1 instead of 1.5.0.

## Motivation

Stay up to date with docs.
